### PR TITLE
Fix Docker client tests failing on CI

### DIFF
--- a/src/lws/providers/lambda_runtime/docker.py
+++ b/src/lws/providers/lambda_runtime/docker.py
@@ -60,6 +60,18 @@ _RUNTIME_IMAGES: dict[str, str] = {
 _EOL_RUNTIMES: set[str] = {"nodejs14.x", "nodejs16.x", "python3.8"}
 
 
+def _socket_candidates() -> list[Path]:
+    """Return well-known Docker socket paths to probe."""
+    home = Path.home()
+    return [
+        home / ".colima" / "default" / "docker.sock",
+        home / ".colima" / "docker.sock",
+        home / ".rd" / "docker.sock",
+        Path("/var/run/docker.sock"),
+        home / ".docker" / "run" / "docker.sock",
+    ]
+
+
 def create_docker_client():
     """Create a Docker client, discovering the socket if necessary.
 
@@ -78,15 +90,7 @@ def create_docker_client():
         pass
 
     # Probe well-known alternative socket paths.
-    home = Path.home()
-    candidates = [
-        home / ".colima" / "default" / "docker.sock",
-        home / ".colima" / "docker.sock",
-        home / ".rd" / "docker.sock",
-        Path("/var/run/docker.sock"),
-        home / ".docker" / "run" / "docker.sock",
-    ]
-    for sock in candidates:
+    for sock in _socket_candidates():
         if sock.exists():
             try:
                 client = docker.DockerClient(base_url=f"unix://{sock}")

--- a/tests/unit/providers/test_docker_create_client_from_env.py
+++ b/tests/unit/providers/test_docker_create_client_from_env.py
@@ -37,13 +37,15 @@ class TestCreateDockerClientFromEnv:
         mock_docker.from_env.return_value = mock_env_client
         mock_docker.DockerClient.return_value = mock_sock_client
 
-        sock_path = tmp_path / ".colima" / "default" / "docker.sock"
-        sock_path.parent.mkdir(parents=True)
+        sock_path = tmp_path / "docker.sock"
         sock_path.touch()
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[sock_path],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 

--- a/tests/unit/providers/test_docker_create_client_no_docker.py
+++ b/tests/unit/providers/test_docker_create_client_no_docker.py
@@ -21,7 +21,10 @@ class TestCreateDockerClientNoDocker:
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[tmp_path / "nonexistent.sock"],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 

--- a/tests/unit/providers/test_docker_create_client_socket_discovery.py
+++ b/tests/unit/providers/test_docker_create_client_socket_discovery.py
@@ -26,7 +26,10 @@ class TestCreateDockerClientSocketDiscovery:
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[expected_sock],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 
@@ -55,7 +58,10 @@ class TestCreateDockerClientSocketDiscovery:
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[expected_sock],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 
@@ -84,7 +90,10 @@ class TestCreateDockerClientSocketDiscovery:
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[expected_sock],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 
@@ -110,18 +119,18 @@ class TestCreateDockerClientSocketDiscovery:
         mock_docker.from_env.return_value = mock_env_client
         mock_docker.DockerClient.side_effect = [mock_bad_client, mock_good_client]
 
-        # Create two sockets — first will fail ping, second will succeed
-        bad_sock = tmp_path / ".colima" / "default" / "docker.sock"
-        bad_sock.parent.mkdir(parents=True)
+        bad_sock = tmp_path / "bad.sock"
         bad_sock.touch()
 
-        good_sock = tmp_path / ".colima" / "docker.sock"
-        good_sock.parent.mkdir(parents=True, exist_ok=True)
+        good_sock = tmp_path / "good.sock"
         good_sock.touch()
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),
-            patch("pathlib.Path.home", return_value=tmp_path),
+            patch(
+                "lws.providers.lambda_runtime.docker._socket_candidates",
+                return_value=[bad_sock, good_sock],
+            ),
         ):
             from lws.providers.lambda_runtime.docker import create_docker_client
 


### PR DESCRIPTION
## Summary

- Extract socket candidate paths into `_socket_candidates()` function so tests can patch the list directly
- Tests now use `patch("lws.providers.lambda_runtime.docker._socket_candidates")` instead of `patch("pathlib.Path.home")`, avoiding interference from real Docker sockets on the CI runner

## Root Cause

On GitHub Actions runners, `/var/run/docker.sock` exists and the Docker daemon responds to ping. Since this is an absolute path (not relative to `Path.home()`), mocking `Path.home()` had no effect on it. Tests that expected a specific socket to be used or expected no daemon to be found were failing because the real socket was found first.

## Test plan

- [x] `uv run pytest tests/unit/providers/test_docker_create_client_*.py -v` — all 7 tests pass
- [x] `make check` — 1742 passed, all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)