### PR TITLE
Fix Node.js Lambda SDK resolution and DynamoDB UpdateItem JSON format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-web-services"
-version = "0.7.0"
+version = "0.7.1"
 description = "Run AWS CDK applications locally - accelerate development with agentic code editors"
 readme = "README.md"
 license = "MIT"

--- a/src/lws/providers/lambda_runtime/docker.py
+++ b/src/lws/providers/lambda_runtime/docker.py
@@ -344,6 +344,10 @@ class DockerCompute(ICompute):
             existing = env.get("NODE_OPTIONS", "")
             preload = "--require /var/bootstrap/dns_rewrite.js"
             env["NODE_OPTIONS"] = f"{existing} {preload}".strip()
+            # Make the runtime's pre-installed AWS SDK accessible to user code,
+            # matching real AWS Lambda behavior where the SDK is available
+            # without bundling.
+            env["NODE_PATH"] = "/var/runtime/node_modules"
         return env
 
     def _build_exec_env(self, context: LambdaContext) -> list[str]:

--- a/tests/unit/providers/test_dynamodb_provider_ensure_dynamo_json.py
+++ b/tests/unit/providers/test_dynamodb_provider_ensure_dynamo_json.py
@@ -1,0 +1,58 @@
+"""Tests for _ensure_dynamo_json item-level helper."""
+
+from __future__ import annotations
+
+from lws.providers.dynamodb.provider import (
+    _ensure_dynamo_json,
+)
+
+
+class TestEnsureDynamoJson:
+    """_ensure_dynamo_json normalises mixed-format items to DynamoDB JSON."""
+
+    def test_fully_typed_item_unchanged(self) -> None:
+        # Arrange
+        item = {"orderId": {"S": "o1"}, "status": {"S": "new"}}
+
+        # Act
+        actual_item = _ensure_dynamo_json(item)
+
+        # Assert
+        assert actual_item == item
+
+    def test_fully_plain_item_wrapped(self) -> None:
+        # Arrange
+        expected_item = {"orderId": {"S": "o1"}, "count": {"N": "3"}}
+
+        # Act
+        actual_item = _ensure_dynamo_json({"orderId": "o1", "count": 3})
+
+        # Assert
+        assert actual_item == expected_item
+
+    def test_mixed_item_normalised(self) -> None:
+        # Arrange
+        mixed_item = {
+            "orderId": {"S": "o1"},
+            "status": "PROCESSED",
+            "count": 5,
+        }
+        expected_item = {
+            "orderId": {"S": "o1"},
+            "status": {"S": "PROCESSED"},
+            "count": {"N": "5"},
+        }
+
+        # Act
+        actual_item = _ensure_dynamo_json(mixed_item)
+
+        # Assert
+        assert actual_item == expected_item
+
+    def test_empty_item(self) -> None:
+        # Arrange
+        # Act
+        actual_item = _ensure_dynamo_json({})
+
+        # Assert
+        assert actual_item == {}

--- a/tests/unit/providers/test_dynamodb_provider_ensure_dynamo_json_value.py
+++ b/tests/unit/providers/test_dynamodb_provider_ensure_dynamo_json_value.py
@@ -1,0 +1,101 @@
+"""Tests for _ensure_dynamo_json_value single-value helper."""
+
+from __future__ import annotations
+
+from lws.providers.dynamodb.provider import (
+    _ensure_dynamo_json_value,
+)
+
+
+class TestEnsureDynamoJsonValue:
+    """_ensure_dynamo_json_value wraps plain values and preserves typed ones."""
+
+    def test_plain_string_wrapped(self) -> None:
+        # Arrange
+        expected_value = {"S": "hello"}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value("hello")
+
+        # Assert
+        assert actual_value == expected_value
+
+    def test_plain_int_wrapped(self) -> None:
+        # Arrange
+        expected_value = {"N": "42"}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(42)
+
+        # Assert
+        assert actual_value == expected_value
+
+    def test_plain_bool_wrapped(self) -> None:
+        # Arrange
+        expected_value = {"BOOL": True}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(True)
+
+        # Assert
+        assert actual_value == expected_value
+
+    def test_plain_none_wrapped(self) -> None:
+        # Arrange
+        expected_value = {"NULL": True}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(None)
+
+        # Assert
+        assert actual_value == expected_value
+
+    def test_typed_string_preserved(self) -> None:
+        # Arrange
+        typed_value = {"S": "hello"}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(typed_value)
+
+        # Assert
+        assert actual_value == typed_value
+
+    def test_typed_number_preserved(self) -> None:
+        # Arrange
+        typed_value = {"N": "42"}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(typed_value)
+
+        # Assert
+        assert actual_value == typed_value
+
+    def test_typed_bool_preserved(self) -> None:
+        # Arrange
+        typed_value = {"BOOL": False}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(typed_value)
+
+        # Assert
+        assert actual_value == typed_value
+
+    def test_typed_list_preserved(self) -> None:
+        # Arrange
+        typed_value = {"L": [{"S": "a"}, {"N": "1"}]}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(typed_value)
+
+        # Assert
+        assert actual_value == typed_value
+
+    def test_typed_map_preserved(self) -> None:
+        # Arrange
+        typed_value = {"M": {"name": {"S": "Alice"}}}
+
+        # Act
+        actual_value = _ensure_dynamo_json_value(typed_value)
+
+        # Assert
+        assert actual_value == typed_value

--- a/tests/unit/providers/test_dynamodb_provider_update_item_dynamo_json.py
+++ b/tests/unit/providers/test_dynamodb_provider_update_item_dynamo_json.py
@@ -1,0 +1,145 @@
+"""Tests for update_item with DynamoDB JSON input (real SDK wire format)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lws.interfaces import (
+    KeyAttribute,
+    KeySchema,
+    TableConfig,
+)
+from lws.providers.dynamodb.provider import SqliteDynamoProvider
+
+
+def _simple_table_config() -> TableConfig:
+    """Table with partition + sort key."""
+    return TableConfig(
+        table_name="orders",
+        key_schema=KeySchema(
+            partition_key=KeyAttribute(name="orderId", type="S"),
+            sort_key=KeyAttribute(name="itemId", type="S"),
+        ),
+    )
+
+
+@pytest.fixture
+async def provider(tmp_path: Path):
+    """Create, start, yield, and stop a provider with a simple table."""
+    p = SqliteDynamoProvider(
+        data_dir=tmp_path,
+        tables=[_simple_table_config()],
+    )
+    await p.start()
+    yield p
+    await p.stop()
+
+
+class TestUpdateItemDynamoJson:
+    """update_item preserves DynamoDB JSON when items are stored typed."""
+
+    async def test_set_preserves_dynamo_json_format(self, provider: SqliteDynamoProvider) -> None:
+        # Arrange
+        await provider.put_item(
+            "orders",
+            {
+                "orderId": {"S": "o1"},
+                "itemId": {"S": "i1"},
+                "status": {"S": "new"},
+            },
+        )
+        expected_status = {"S": "PROCESSED"}
+
+        # Act
+        result = await provider.update_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+            "SET #s = :v",
+            expression_values={":v": {"S": "PROCESSED"}},
+            expression_names={"#s": "status"},
+        )
+
+        # Assert
+        actual_status = result["status"]
+        assert actual_status == expected_status
+
+    async def test_set_new_attribute_stays_dynamo_json(
+        self, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        await provider.put_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+        )
+        expected_note = {"S": "urgent"}
+
+        # Act
+        result = await provider.update_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+            "SET note = :v",
+            expression_values={":v": {"S": "urgent"}},
+        )
+
+        # Assert
+        actual_note = result["note"]
+        assert actual_note == expected_note
+
+    async def test_get_after_update_returns_dynamo_json(
+        self, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        await provider.put_item(
+            "orders",
+            {
+                "orderId": {"S": "o1"},
+                "itemId": {"S": "i1"},
+                "status": {"S": "new"},
+            },
+        )
+        expected_status = {"S": "shipped"}
+
+        # Act
+        await provider.update_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+            "SET #s = :v",
+            expression_values={":v": {"S": "shipped"}},
+            expression_names={"#s": "status"},
+        )
+        fetched = await provider.get_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+        )
+
+        # Assert
+        actual_status = fetched["status"]
+        assert actual_status == expected_status
+
+    async def test_set_numeric_attribute_stays_dynamo_json(
+        self, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        await provider.put_item(
+            "orders",
+            {
+                "orderId": {"S": "o1"},
+                "itemId": {"S": "i1"},
+                "qty": {"N": "1"},
+            },
+        )
+        expected_qty = {"N": "10"}
+
+        # Act
+        result = await provider.update_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}},
+            "SET qty = :v",
+            expression_values={":v": {"N": "10"}},
+        )
+
+        # Assert
+        actual_qty = result["qty"]
+        assert actual_qty == expected_qty

--- a/uv.lock
+++ b/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "local-web-services"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- **Node.js Lambda SDK resolution**: Set `NODE_PATH=/var/runtime/node_modules` in Docker Lambda containers so user code can `require('@aws-sdk/...')` without bundling, matching real AWS Lambda behavior where SDK v3 is pre-installed.
- **DynamoDB UpdateItem JSON format**: Fix the update expression evaluator corrupting DynamoDB JSON items to mixed format. The evaluator unwraps typed values (`{"S": "PROCESSED"}` → `"PROCESSED"`) before setting them on items, causing SDK v3 deserialization errors. Added `_ensure_dynamo_json` helpers to re-wrap plain values after evaluation.
- Bump version to 0.7.1.

## Test plan

- [ ] `make check` passes (lint, format, complexity, 2074 tests)
- [ ] New unit tests for `_ensure_dynamo_json` and `_ensure_dynamo_json_value` helpers
- [ ] New unit tests for `update_item` with DynamoDB JSON input (real SDK wire format)
- [ ] Existing `update_item` tests with plain input still pass (backward compat)
- [ ] E2E: sample-project OrderWorkflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)