### PR TITLE
Add 100+ CLI commands across all serverless services

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-web-services"
-version = "0.7.1"
+version = "0.8.0"
 description = "Run AWS CDK applications locally - accelerate development with agentic code editors"
 readme = "README.md"
 license = "MIT"

--- a/src/lws/cli/services/apigateway.py
+++ b/src/lws/cli/services/apigateway.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -15,6 +16,11 @@ _SERVICE = "apigateway"
 
 def _client(port: int) -> LwsClient:
     return LwsClient(port=port)
+
+
+# ---------------------------------------------------------------------------
+# test-invoke-method (existing — uses httpx directly)
+# ---------------------------------------------------------------------------
 
 
 @app.command("test-invoke-method")
@@ -70,3 +76,1130 @@ async def _test_invoke_method(
         "body": resp_body,
     }
     output_json(result)
+
+
+# ---------------------------------------------------------------------------
+# REST API (V1) management commands
+# ---------------------------------------------------------------------------
+
+
+@app.command("create-rest-api")
+def create_rest_api(
+    name: str = typer.Option(..., "--name", help="REST API name"),
+    description: str = typer.Option("", "--description", help="REST API description"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a new REST API."""
+    asyncio.run(_create_rest_api(name, description, port))
+
+
+async def _create_rest_api(name: str, description: str, port: int) -> None:
+    client = _client(port)
+    json_body = json.dumps({"name": name, "description": description}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            "/restapis",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("list-rest-apis")
+def list_rest_apis(
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List all REST APIs."""
+    asyncio.run(_list_rest_apis(port))
+
+
+async def _list_rest_apis(port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", "/restapis")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-rest-api")
+def get_rest_api(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a REST API by ID."""
+    asyncio.run(_get_rest_api(rest_api_id, port))
+
+
+async def _get_rest_api(rest_api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", f"/restapis/{rest_api_id}")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("update-rest-api")
+def update_rest_api(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    patch_operations: str = typer.Option(
+        ..., "--patch-operations", help="JSON array of patch operations"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a REST API."""
+    asyncio.run(_update_rest_api(rest_api_id, patch_operations, port))
+
+
+async def _update_rest_api(rest_api_id: str, patch_operations: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(patch_operations)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --patch-operations: {exc}")
+    json_body = json.dumps({"patchOperations": parsed}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PATCH",
+            f"/restapis/{rest_api_id}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-rest-api")
+def delete_rest_api(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a REST API."""
+    asyncio.run(_delete_rest_api(rest_api_id, port))
+
+
+async def _delete_rest_api(rest_api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "DELETE", f"/restapis/{rest_api_id}")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("get-resources")
+def get_resources(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get resources for a REST API."""
+    asyncio.run(_get_resources(rest_api_id, port))
+
+
+async def _get_resources(rest_api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/resources",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("create-resource")
+def create_resource(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    parent_id: str = typer.Option(..., "--parent-id", help="Parent resource ID"),
+    path_part: str = typer.Option(..., "--path-part", help="Path part for the resource"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a resource under a parent resource."""
+    asyncio.run(_create_resource(rest_api_id, parent_id, path_part, port))
+
+
+async def _create_resource(rest_api_id: str, parent_id: str, path_part: str, port: int) -> None:
+    client = _client(port)
+    json_body = json.dumps({"pathPart": path_part}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/restapis/{rest_api_id}/resources/{parent_id}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-resource")
+def delete_resource(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a resource."""
+    asyncio.run(_delete_resource(rest_api_id, resource_id, port))
+
+
+async def _delete_resource(rest_api_id: str, resource_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/restapis/{rest_api_id}/resources/{resource_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("put-method")
+def put_method(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    authorization_type: str = typer.Option(
+        "NONE", "--authorization-type", help="Authorization type"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add a method to a resource."""
+    asyncio.run(_put_method(rest_api_id, resource_id, http_method, authorization_type, port))
+
+
+async def _put_method(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    authorization_type: str,
+    port: int,
+) -> None:
+    client = _client(port)
+    json_body = json.dumps({"authorizationType": authorization_type}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-method")
+def get_method(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a method on a resource."""
+    asyncio.run(_get_method(rest_api_id, resource_id, http_method, port))
+
+
+async def _get_method(rest_api_id: str, resource_id: str, http_method: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-method")
+def delete_method(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a method from a resource."""
+    asyncio.run(_delete_method(rest_api_id, resource_id, http_method, port))
+
+
+async def _delete_method(rest_api_id: str, resource_id: str, http_method: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("put-integration")
+def put_integration(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    integration_type: str = typer.Option(..., "--type", help="Integration type"),
+    integration_http_method: str = typer.Option(
+        None, "--integration-http-method", help="Integration HTTP method"
+    ),
+    uri: str = typer.Option(None, "--uri", help="Integration URI"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add an integration to a method."""
+    asyncio.run(
+        _put_integration(
+            rest_api_id,
+            resource_id,
+            http_method,
+            integration_type,
+            integration_http_method,
+            uri,
+            port,
+        )
+    )
+
+
+async def _put_integration(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    integration_type: str,
+    integration_http_method: str | None,
+    uri: str | None,
+    port: int,
+) -> None:
+    client = _client(port)
+    body: dict = {"type": integration_type}
+    if integration_http_method:
+        body["integrationHttpMethod"] = integration_http_method
+    if uri:
+        body["uri"] = uri
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}/integration",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-integration")
+def get_integration(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get the integration for a method."""
+    asyncio.run(_get_integration(rest_api_id, resource_id, http_method, port))
+
+
+async def _get_integration(rest_api_id: str, resource_id: str, http_method: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}/integration",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-integration")
+def delete_integration(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete the integration for a method."""
+    asyncio.run(_delete_integration(rest_api_id, resource_id, http_method, port))
+
+
+async def _delete_integration(
+    rest_api_id: str, resource_id: str, http_method: str, port: int
+) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/restapis/{rest_api_id}/resources/{resource_id}/methods/{http_method}/integration",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("put-integration-response")
+def put_integration_response(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    status_code: str = typer.Option(..., "--status-code", help="Status code"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add an integration response."""
+    asyncio.run(_put_integration_response(rest_api_id, resource_id, http_method, status_code, port))
+
+
+async def _put_integration_response(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    status_code: str,
+    port: int,
+) -> None:
+    client = _client(port)
+    json_body = json.dumps({"statusCode": status_code}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/restapis/{rest_api_id}/resources/{resource_id}"
+            f"/methods/{http_method}/integration/responses/{status_code}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-integration-response")
+def get_integration_response(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    status_code: str = typer.Option(..., "--status-code", help="Status code"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get an integration response."""
+    asyncio.run(_get_integration_response(rest_api_id, resource_id, http_method, status_code, port))
+
+
+async def _get_integration_response(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    status_code: str,
+    port: int,
+) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/resources/{resource_id}"
+            f"/methods/{http_method}/integration/responses/{status_code}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("put-method-response")
+def put_method_response(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    status_code: str = typer.Option(..., "--status-code", help="Status code"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add a method response."""
+    asyncio.run(_put_method_response(rest_api_id, resource_id, http_method, status_code, port))
+
+
+async def _put_method_response(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    status_code: str,
+    port: int,
+) -> None:
+    client = _client(port)
+    json_body = json.dumps({"statusCode": status_code}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/restapis/{rest_api_id}/resources/{resource_id}"
+            f"/methods/{http_method}/responses/{status_code}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-method-response")
+def get_method_response(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    http_method: str = typer.Option(..., "--http-method", help="HTTP method"),
+    status_code: str = typer.Option(..., "--status-code", help="Status code"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a method response."""
+    asyncio.run(_get_method_response(rest_api_id, resource_id, http_method, status_code, port))
+
+
+async def _get_method_response(
+    rest_api_id: str,
+    resource_id: str,
+    http_method: str,
+    status_code: str,
+    port: int,
+) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/resources/{resource_id}"
+            f"/methods/{http_method}/responses/{status_code}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("create-deployment")
+def create_deployment(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    stage_name: str = typer.Option(None, "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a deployment for a REST API."""
+    asyncio.run(_create_deployment(rest_api_id, stage_name, port))
+
+
+async def _create_deployment(rest_api_id: str, stage_name: str | None, port: int) -> None:
+    client = _client(port)
+    body: dict = {}
+    if stage_name:
+        body["stageName"] = stage_name
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/restapis/{rest_api_id}/deployments",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("list-deployments")
+def list_deployments(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List deployments for a REST API."""
+    asyncio.run(_list_deployments(rest_api_id, port))
+
+
+async def _list_deployments(rest_api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/deployments",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-deployment")
+def get_deployment(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    deployment_id: str = typer.Option(..., "--deployment-id", help="Deployment ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a deployment by ID."""
+    asyncio.run(_get_deployment(rest_api_id, deployment_id, port))
+
+
+async def _get_deployment(rest_api_id: str, deployment_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/deployments/{deployment_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("create-stage")
+def create_stage(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    deployment_id: str = typer.Option(..., "--deployment-id", help="Deployment ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a stage for a REST API."""
+    asyncio.run(_create_stage(rest_api_id, stage_name, deployment_id, port))
+
+
+async def _create_stage(rest_api_id: str, stage_name: str, deployment_id: str, port: int) -> None:
+    client = _client(port)
+    json_body = json.dumps({"stageName": stage_name, "deploymentId": deployment_id}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/restapis/{rest_api_id}/stages",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-stage")
+def get_stage(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a stage by name."""
+    asyncio.run(_get_stage(rest_api_id, stage_name, port))
+
+
+async def _get_stage(rest_api_id: str, stage_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/restapis/{rest_api_id}/stages/{stage_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("update-stage")
+def update_stage(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    patch_operations: str = typer.Option(
+        ..., "--patch-operations", help="JSON array of patch operations"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a stage."""
+    asyncio.run(_update_stage(rest_api_id, stage_name, patch_operations, port))
+
+
+async def _update_stage(
+    rest_api_id: str, stage_name: str, patch_operations: str, port: int
+) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(patch_operations)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --patch-operations: {exc}")
+    json_body = json.dumps({"patchOperations": parsed}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PATCH",
+            f"/restapis/{rest_api_id}/stages/{stage_name}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-stage")
+def delete_stage(
+    rest_api_id: str = typer.Option(..., "--rest-api-id", help="REST API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a stage."""
+    asyncio.run(_delete_stage(rest_api_id, stage_name, port))
+
+
+async def _delete_stage(rest_api_id: str, stage_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/restapis/{rest_api_id}/stages/{stage_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+# ---------------------------------------------------------------------------
+# HTTP API (V2) management commands
+# ---------------------------------------------------------------------------
+
+
+@app.command("v2-create-api")
+def v2_create_api(
+    name: str = typer.Option(..., "--name", help="API name"),
+    protocol_type: str = typer.Option("HTTP", "--protocol-type", help="Protocol type"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a new HTTP API (V2)."""
+    asyncio.run(_v2_create_api(name, protocol_type, port))
+
+
+async def _v2_create_api(name: str, protocol_type: str, port: int) -> None:
+    client = _client(port)
+    json_body = json.dumps({"Name": name, "ProtocolType": protocol_type}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            "/v2/apis",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-list-apis")
+def v2_list_apis(
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List all HTTP APIs (V2)."""
+    asyncio.run(_v2_list_apis(port))
+
+
+async def _v2_list_apis(port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", "/v2/apis")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-get-api")
+def v2_get_api(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get an HTTP API (V2) by ID."""
+    asyncio.run(_v2_get_api(api_id, port))
+
+
+async def _v2_get_api(api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", f"/v2/apis/{api_id}")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-update-api")
+def v2_update_api(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    name: str = typer.Option(None, "--name", help="New API name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update an HTTP API (V2)."""
+    asyncio.run(_v2_update_api(api_id, name, port))
+
+
+async def _v2_update_api(api_id: str, name: str | None, port: int) -> None:
+    client = _client(port)
+    body: dict = {}
+    if name:
+        body["Name"] = name
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PATCH",
+            f"/v2/apis/{api_id}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-delete-api")
+def v2_delete_api(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete an HTTP API (V2)."""
+    asyncio.run(_v2_delete_api(api_id, port))
+
+
+async def _v2_delete_api(api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "DELETE", f"/v2/apis/{api_id}")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("v2-create-stage")
+def v2_create_stage(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a stage for an HTTP API (V2)."""
+    asyncio.run(_v2_create_stage(api_id, stage_name, port))
+
+
+async def _v2_create_stage(api_id: str, stage_name: str, port: int) -> None:
+    client = _client(port)
+    json_body = json.dumps({"StageName": stage_name}).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/v2/apis/{api_id}/stages",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-get-stage")
+def v2_get_stage(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a stage for an HTTP API (V2)."""
+    asyncio.run(_v2_get_stage(api_id, stage_name, port))
+
+
+async def _v2_get_stage(api_id: str, stage_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/v2/apis/{api_id}/stages/{stage_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-update-stage")
+def v2_update_stage(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    patch_operations: str = typer.Option(
+        None, "--patch-operations", help="JSON array of patch operations"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a stage for an HTTP API (V2)."""
+    asyncio.run(_v2_update_stage(api_id, stage_name, patch_operations, port))
+
+
+async def _v2_update_stage(
+    api_id: str, stage_name: str, patch_operations: str | None, port: int
+) -> None:
+    client = _client(port)
+    body: dict = {}
+    if patch_operations:
+        try:
+            body["patchOperations"] = json.loads(patch_operations)
+        except json.JSONDecodeError as exc:
+            exit_with_error(f"Invalid JSON in --patch-operations: {exc}")
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PATCH",
+            f"/v2/apis/{api_id}/stages/{stage_name}",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-delete-stage")
+def v2_delete_stage(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    stage_name: str = typer.Option(..., "--stage-name", help="Stage name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a stage for an HTTP API (V2)."""
+    asyncio.run(_v2_delete_stage(api_id, stage_name, port))
+
+
+async def _v2_delete_stage(api_id: str, stage_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/v2/apis/{api_id}/stages/{stage_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("v2-list-stages")
+def v2_list_stages(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List stages for an HTTP API (V2)."""
+    asyncio.run(_v2_list_stages(api_id, port))
+
+
+async def _v2_list_stages(api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", f"/v2/apis/{api_id}/stages")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-create-integration")
+def v2_create_integration(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    integration_type: str = typer.Option(..., "--integration-type", help="Integration type"),
+    integration_uri: str = typer.Option(None, "--integration-uri", help="Integration URI"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create an integration for an HTTP API (V2)."""
+    asyncio.run(_v2_create_integration(api_id, integration_type, integration_uri, port))
+
+
+async def _v2_create_integration(
+    api_id: str, integration_type: str, integration_uri: str | None, port: int
+) -> None:
+    client = _client(port)
+    body: dict = {"IntegrationType": integration_type}
+    if integration_uri:
+        body["IntegrationUri"] = integration_uri
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/v2/apis/{api_id}/integrations",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-list-integrations")
+def v2_list_integrations(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List integrations for an HTTP API (V2)."""
+    asyncio.run(_v2_list_integrations(api_id, port))
+
+
+async def _v2_list_integrations(api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/v2/apis/{api_id}/integrations",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-get-integration")
+def v2_get_integration(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    integration_id: str = typer.Option(..., "--integration-id", help="Integration ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get an integration for an HTTP API (V2)."""
+    asyncio.run(_v2_get_integration(api_id, integration_id, port))
+
+
+async def _v2_get_integration(api_id: str, integration_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/v2/apis/{api_id}/integrations/{integration_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-delete-integration")
+def v2_delete_integration(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    integration_id: str = typer.Option(..., "--integration-id", help="Integration ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete an integration for an HTTP API (V2)."""
+    asyncio.run(_v2_delete_integration(api_id, integration_id, port))
+
+
+async def _v2_delete_integration(api_id: str, integration_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/v2/apis/{api_id}/integrations/{integration_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("v2-create-route")
+def v2_create_route(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    route_key: str = typer.Option(..., "--route-key", help="Route key (e.g. GET /items)"),
+    target: str = typer.Option(None, "--target", help="Integration target"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a route for an HTTP API (V2)."""
+    asyncio.run(_v2_create_route(api_id, route_key, target, port))
+
+
+async def _v2_create_route(api_id: str, route_key: str, target: str | None, port: int) -> None:
+    client = _client(port)
+    body: dict = {"RouteKey": route_key}
+    if target:
+        body["Target"] = target
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            f"/v2/apis/{api_id}/routes",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-list-routes")
+def v2_list_routes(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List routes for an HTTP API (V2)."""
+    asyncio.run(_v2_list_routes(api_id, port))
+
+
+async def _v2_list_routes(api_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(_SERVICE, "GET", f"/v2/apis/{api_id}/routes")
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-get-route")
+def v2_get_route(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    route_id: str = typer.Option(..., "--route-id", help="Route ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a route for an HTTP API (V2)."""
+    asyncio.run(_v2_get_route(api_id, route_id, port))
+
+
+async def _v2_get_route(api_id: str, route_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/v2/apis/{api_id}/routes/{route_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("v2-delete-route")
+def v2_delete_route(
+    api_id: str = typer.Option(..., "--api-id", help="API ID"),
+    route_id: str = typer.Option(..., "--route-id", help="Route ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a route for an HTTP API (V2)."""
+    asyncio.run(_v2_delete_route(api_id, route_id, port))
+
+
+async def _v2_delete_route(api_id: str, route_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/v2/apis/{api_id}/routes/{route_id}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})

--- a/src/lws/cli/services/client.py
+++ b/src/lws/cli/services/client.py
@@ -126,6 +126,25 @@ class LwsClient:
         return resp
 
 
+def parse_json_option(value: str, option_name: str) -> Any:
+    """Parse a JSON CLI option, exiting with a friendly error on failure."""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in {option_name}: {exc}")
+        return None  # unreachable; satisfies pylint R1710
+
+
+async def json_request_output(port: int, service: str, target: str, body: dict[str, Any]) -> None:
+    """Make a JSON-target request and print the result. Shared by tag helpers."""
+    client = LwsClient(port=port)
+    try:
+        result = await client.json_target_request(service, target, body)
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
 def output_json(data: Any) -> None:
     """Print *data* as formatted JSON to stdout."""
     print(json.dumps(data, indent=2, default=str))

--- a/src/lws/cli/services/cognito.py
+++ b/src/lws/cli/services/cognito.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -197,6 +198,347 @@ async def _describe_user_pool(user_pool_id: str, port: int) -> None:
             _SERVICE,
             f"{_TARGET_PREFIX}.DescribeUserPool",
             {"UserPoolId": user_pool_id},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("forgot-password")
+def forgot_password(
+    user_pool_name: str = typer.Option(..., "--user-pool-name", help="User pool name"),
+    username: str = typer.Option(..., "--username", help="Username"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Initiate a forgot password flow."""
+    asyncio.run(_forgot_password(user_pool_name, username, port))
+
+
+async def _forgot_password(user_pool_name: str, username: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, user_pool_name)
+        client_id = resource.get("user_pool_id", "local-client-id")
+    except Exception:
+        client_id = "local-client-id"
+    result = await client.json_target_request(
+        _SERVICE,
+        f"{_TARGET_PREFIX}.ForgotPassword",
+        {
+            "ClientId": client_id,
+            "Username": username,
+        },
+        content_type="application/x-amz-json-1.1",
+    )
+    output_json(result)
+
+
+@app.command("confirm-forgot-password")
+def confirm_forgot_password(
+    user_pool_name: str = typer.Option(..., "--user-pool-name", help="User pool name"),
+    username: str = typer.Option(..., "--username", help="Username"),
+    confirmation_code: str = typer.Option(..., "--confirmation-code", help="Confirmation code"),
+    password: str = typer.Option(..., "--password", help="New password"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Confirm a forgot password with a confirmation code."""
+    asyncio.run(
+        _confirm_forgot_password(user_pool_name, username, confirmation_code, password, port)
+    )
+
+
+async def _confirm_forgot_password(
+    user_pool_name: str, username: str, confirmation_code: str, password: str, port: int
+) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, user_pool_name)
+        client_id = resource.get("user_pool_id", "local-client-id")
+    except Exception:
+        client_id = "local-client-id"
+    result = await client.json_target_request(
+        _SERVICE,
+        f"{_TARGET_PREFIX}.ConfirmForgotPassword",
+        {
+            "ClientId": client_id,
+            "Username": username,
+            "ConfirmationCode": confirmation_code,
+            "Password": password,
+        },
+        content_type="application/x-amz-json-1.1",
+    )
+    output_json(result)
+
+
+@app.command("change-password")
+def change_password(
+    access_token: str = typer.Option(..., "--access-token", help="Access token"),
+    previous_password: str = typer.Option(..., "--previous-password", help="Previous password"),
+    proposed_password: str = typer.Option(..., "--proposed-password", help="Proposed new password"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Change a user's password using an access token."""
+    asyncio.run(_change_password(access_token, previous_password, proposed_password, port))
+
+
+async def _change_password(
+    access_token: str, previous_password: str, proposed_password: str, port: int
+) -> None:
+    client = _client(port)
+    result = await client.json_target_request(
+        _SERVICE,
+        f"{_TARGET_PREFIX}.ChangePassword",
+        {
+            "AccessToken": access_token,
+            "PreviousPassword": previous_password,
+            "ProposedPassword": proposed_password,
+        },
+        content_type="application/x-amz-json-1.1",
+    )
+    output_json(result)
+
+
+@app.command("global-sign-out")
+def global_sign_out(
+    access_token: str = typer.Option(..., "--access-token", help="Access token"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Sign out a user from all devices."""
+    asyncio.run(_global_sign_out(access_token, port))
+
+
+async def _global_sign_out(access_token: str, port: int) -> None:
+    client = _client(port)
+    result = await client.json_target_request(
+        _SERVICE,
+        f"{_TARGET_PREFIX}.GlobalSignOut",
+        {"AccessToken": access_token},
+        content_type="application/x-amz-json-1.1",
+    )
+    output_json(result)
+
+
+@app.command("create-user-pool-client")
+def create_user_pool_client(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    client_name: str = typer.Option(..., "--client-name", help="Client name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a user pool client."""
+    asyncio.run(_create_user_pool_client(user_pool_id, client_name, port))
+
+
+async def _create_user_pool_client(user_pool_id: str, client_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.CreateUserPoolClient",
+            {"UserPoolId": user_pool_id, "ClientName": client_name},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("delete-user-pool-client")
+def delete_user_pool_client(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    client_id: str = typer.Option(..., "--client-id", help="Client ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a user pool client."""
+    asyncio.run(_delete_user_pool_client(user_pool_id, client_id, port))
+
+
+async def _delete_user_pool_client(user_pool_id: str, client_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DeleteUserPoolClient",
+            {"UserPoolId": user_pool_id, "ClientId": client_id},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("describe-user-pool-client")
+def describe_user_pool_client(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    client_id: str = typer.Option(..., "--client-id", help="Client ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Describe a user pool client."""
+    asyncio.run(_describe_user_pool_client(user_pool_id, client_id, port))
+
+
+async def _describe_user_pool_client(user_pool_id: str, client_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DescribeUserPoolClient",
+            {"UserPoolId": user_pool_id, "ClientId": client_id},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-user-pool-clients")
+def list_user_pool_clients(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List user pool clients."""
+    asyncio.run(_list_user_pool_clients(user_pool_id, port))
+
+
+async def _list_user_pool_clients(user_pool_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListUserPoolClients",
+            {"UserPoolId": user_pool_id, "MaxResults": 60},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("admin-create-user")
+def admin_create_user(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    username: str = typer.Option(..., "--username", help="Username"),
+    temporary_password: str = typer.Option(None, "--temporary-password", help="Temporary password"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Admin create a user."""
+    asyncio.run(_admin_create_user(user_pool_id, username, temporary_password, port))
+
+
+async def _admin_create_user(
+    user_pool_id: str, username: str, temporary_password: str | None, port: int
+) -> None:
+    client = _client(port)
+    body: dict = {"UserPoolId": user_pool_id, "Username": username}
+    if temporary_password is not None:
+        body["TemporaryPassword"] = temporary_password
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.AdminCreateUser",
+            body,
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("admin-delete-user")
+def admin_delete_user(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    username: str = typer.Option(..., "--username", help="Username"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Admin delete a user."""
+    asyncio.run(_admin_delete_user(user_pool_id, username, port))
+
+
+async def _admin_delete_user(user_pool_id: str, username: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.AdminDeleteUser",
+            {"UserPoolId": user_pool_id, "Username": username},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("admin-get-user")
+def admin_get_user(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    username: str = typer.Option(..., "--username", help="Username"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Admin get a user."""
+    asyncio.run(_admin_get_user(user_pool_id, username, port))
+
+
+async def _admin_get_user(user_pool_id: str, username: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.AdminGetUser",
+            {"UserPoolId": user_pool_id, "Username": username},
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("update-user-pool")
+def update_user_pool(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    auto_verified_attributes: str = typer.Option(
+        None, "--auto-verified-attributes", help="Auto-verified attributes (JSON array)"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a user pool."""
+    asyncio.run(_update_user_pool(user_pool_id, auto_verified_attributes, port))
+
+
+async def _update_user_pool(
+    user_pool_id: str, auto_verified_attributes: str | None, port: int
+) -> None:
+    client = _client(port)
+    body: dict = {"UserPoolId": user_pool_id}
+    if auto_verified_attributes is not None:
+        body["AutoVerifiedAttributes"] = json.loads(auto_verified_attributes)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.UpdateUserPool",
+            body,
+            content_type="application/x-amz-json-1.1",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-users")
+def list_users(
+    user_pool_id: str = typer.Option(..., "--user-pool-id", help="User pool ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List users in a user pool."""
+    asyncio.run(_list_users(user_pool_id, port))
+
+
+async def _list_users(user_pool_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListUsers",
+            {"UserPoolId": user_pool_id, "Limit": 60},
             content_type="application/x-amz-json-1.1",
         )
     except Exception as exc:

--- a/src/lws/cli/services/dynamodb.py
+++ b/src/lws/cli/services/dynamodb.py
@@ -282,3 +282,168 @@ async def _query(
     except Exception as exc:
         exit_with_error(str(exc))
     output_json(result)
+
+
+@app.command("transact-write-items")
+def transact_write_items(
+    transact_items: str = typer.Option(..., "--transact-items", help="JSON transact items"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Execute a transactional write."""
+    asyncio.run(_transact_write_items(transact_items, port))
+
+
+async def _transact_write_items(transact_items_json: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(transact_items_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --transact-items: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.TransactWriteItems",
+            {"TransactItems": parsed},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("update-item")
+def update_item(
+    table_name: str = typer.Option(..., "--table-name", help="Table name"),
+    key: str = typer.Option(..., "--key", help="JSON key"),
+    update_expression: str = typer.Option(..., "--update-expression", help="Update expression"),
+    expression_attribute_values: str = typer.Option(
+        None, "--expression-attribute-values", help="JSON expression attribute values"
+    ),
+    expression_attribute_names: str = typer.Option(
+        None, "--expression-attribute-names", help="JSON expression attribute names"
+    ),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update an item in a table."""
+    asyncio.run(
+        _update_item(
+            table_name,
+            key,
+            update_expression,
+            expression_attribute_values,
+            expression_attribute_names,
+            port,
+        )
+    )
+
+
+async def _update_item(
+    table_name: str,
+    key_json: str,
+    update_expression: str,
+    expression_attribute_values: str | None,
+    expression_attribute_names: str | None,
+    port: int,
+) -> None:
+    client = _client(port)
+    try:
+        parsed_key = json.loads(key_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --key: {exc}")
+    body: dict = {
+        "TableName": table_name,
+        "Key": parsed_key,
+        "UpdateExpression": update_expression,
+    }
+    if expression_attribute_values:
+        try:
+            body["ExpressionAttributeValues"] = json.loads(expression_attribute_values)
+        except json.JSONDecodeError as exc:
+            exit_with_error(f"Invalid JSON in --expression-attribute-values: {exc}")
+    if expression_attribute_names:
+        try:
+            body["ExpressionAttributeNames"] = json.loads(expression_attribute_names)
+        except json.JSONDecodeError as exc:
+            exit_with_error(f"Invalid JSON in --expression-attribute-names: {exc}")
+    try:
+        result = await client.json_target_request(_SERVICE, f"{_TARGET_PREFIX}.UpdateItem", body)
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("batch-write-item")
+def batch_write_item(
+    request_items: str = typer.Option(..., "--request-items", help="JSON request items"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Execute a batch write."""
+    asyncio.run(_batch_write_item(request_items, port))
+
+
+async def _batch_write_item(request_items_json: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(request_items_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --request-items: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.BatchWriteItem",
+            {"RequestItems": parsed},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("batch-get-item")
+def batch_get_item(
+    request_items: str = typer.Option(..., "--request-items", help="JSON request items"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Execute a batch get."""
+    asyncio.run(_batch_get_item(request_items, port))
+
+
+async def _batch_get_item(request_items_json: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(request_items_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --request-items: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.BatchGetItem",
+            {"RequestItems": parsed},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("transact-get-items")
+def transact_get_items(
+    transact_items: str = typer.Option(..., "--transact-items", help="JSON transact items"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Execute a transactional read."""
+    asyncio.run(_transact_get_items(transact_items, port))
+
+
+async def _transact_get_items(transact_items_json: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed = json.loads(transact_items_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --transact-items: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.TransactGetItems",
+            {"TransactItems": parsed},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)

--- a/src/lws/cli/services/events.py
+++ b/src/lws/cli/services/events.py
@@ -7,7 +7,13 @@ import json
 
 import typer
 
-from lws.cli.services.client import LwsClient, exit_with_error, output_json
+from lws.cli.services.client import (
+    LwsClient,
+    exit_with_error,
+    json_request_output,
+    output_json,
+    parse_json_option,
+)
 
 app = typer.Typer(help="EventBridge commands")
 
@@ -190,3 +196,231 @@ async def _delete_rule(name: str, port: int) -> None:
     except Exception as exc:
         exit_with_error(str(exc))
     output_json(result)
+
+
+@app.command("put-targets")
+def put_targets(
+    rule: str = typer.Option(..., "--rule", help="Rule name"),
+    targets: str = typer.Option(..., "--targets", help="JSON array of targets"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add targets to a rule."""
+    asyncio.run(_put_targets(rule, targets, event_bus_name, port))
+
+
+async def _put_targets(rule: str, targets_json: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_targets = json.loads(targets_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --targets: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.PutTargets",
+            {"Rule": rule, "Targets": parsed_targets, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("remove-targets")
+def remove_targets(
+    rule: str = typer.Option(..., "--rule", help="Rule name"),
+    ids: str = typer.Option(..., "--ids", help="JSON array of target IDs"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Remove targets from a rule."""
+    asyncio.run(_remove_targets(rule, ids, event_bus_name, port))
+
+
+async def _remove_targets(rule: str, ids_json: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_ids = json.loads(ids_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --ids: {exc}")
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.RemoveTargets",
+            {"Rule": rule, "Ids": parsed_ids, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("describe-event-bus")
+def describe_event_bus(
+    name: str = typer.Option("default", "--name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Describe an event bus."""
+    asyncio.run(_describe_event_bus(name, port))
+
+
+async def _describe_event_bus(name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DescribeEventBus",
+            {"Name": name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("describe-rule")
+def describe_rule(
+    name: str = typer.Option(..., "--name", help="Rule name"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Describe a rule."""
+    asyncio.run(_describe_rule(name, event_bus_name, port))
+
+
+async def _describe_rule(name: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DescribeRule",
+            {"Name": name, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-targets-by-rule")
+def list_targets_by_rule(
+    rule: str = typer.Option(..., "--rule", help="Rule name"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List targets for a rule."""
+    asyncio.run(_list_targets_by_rule(rule, event_bus_name, port))
+
+
+async def _list_targets_by_rule(rule: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListTargetsByRule",
+            {"Rule": rule, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("enable-rule")
+def enable_rule(
+    name: str = typer.Option(..., "--name", help="Rule name"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Enable a rule."""
+    asyncio.run(_enable_rule(name, event_bus_name, port))
+
+
+async def _enable_rule(name: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.EnableRule",
+            {"Name": name, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("disable-rule")
+def disable_rule(
+    name: str = typer.Option(..., "--name", help="Rule name"),
+    event_bus_name: str = typer.Option("default", "--event-bus-name", help="Event bus name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Disable a rule."""
+    asyncio.run(_disable_rule(name, event_bus_name, port))
+
+
+async def _disable_rule(name: str, event_bus_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DisableRule",
+            {"Name": name, "EventBusName": event_bus_name},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("tag-resource")
+def tag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    tags: str = typer.Option(..., "--tags", help="JSON array of Key/Value tag objects"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Tag a resource."""
+    asyncio.run(_tag_resource(resource_arn, tags, port))
+
+
+async def _tag_resource(resource_arn: str, tags_json: str, port: int) -> None:
+    parsed_tags = parse_json_option(tags_json, "--tags")
+    await json_request_output(
+        port,
+        _SERVICE,
+        f"{_TARGET_PREFIX}.TagResource",
+        {"ResourceARN": resource_arn, "Tags": parsed_tags},
+    )
+
+
+@app.command("untag-resource")
+def untag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag keys"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Untag a resource."""
+    asyncio.run(_untag_resource(resource_arn, tag_keys, port))
+
+
+async def _untag_resource(resource_arn: str, tag_keys_json: str, port: int) -> None:
+    parsed_keys = parse_json_option(tag_keys_json, "--tag-keys")
+    await json_request_output(
+        port,
+        _SERVICE,
+        f"{_TARGET_PREFIX}.UntagResource",
+        {"ResourceARN": resource_arn, "TagKeys": parsed_keys},
+    )
+
+
+@app.command("list-tags-for-resource")
+def list_tags_for_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List tags for a resource."""
+    asyncio.run(_list_tags_for_resource(resource_arn, port))
+
+
+async def _list_tags_for_resource(resource_arn: str, port: int) -> None:
+    await json_request_output(
+        port,
+        _SERVICE,
+        f"{_TARGET_PREFIX}.ListTagsForResource",
+        {"ResourceARN": resource_arn},
+    )

--- a/src/lws/cli/services/lambda_service.py
+++ b/src/lws/cli/services/lambda_service.py
@@ -9,9 +9,15 @@ from pathlib import Path
 import httpx
 import typer
 
-from lws.cli.services.client import exit_with_error, output_json
+from lws.cli.services.client import LwsClient, exit_with_error, output_json
 
 app = typer.Typer(help="Lambda commands")
+
+_SERVICE = "lambda"
+
+
+def _client(port: int) -> LwsClient:
+    return LwsClient(port=port)
 
 
 @app.command("invoke")
@@ -66,3 +72,260 @@ def _resolve_event_payload(event_json: str | None, event_file: Path | None) -> d
             exit_with_error(f"Invalid JSON in event file: {exc}")
 
     return {}
+
+
+@app.command("create-function")
+def create_function(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    runtime: str = typer.Option(..., "--runtime", help="Runtime (e.g. python3.12)"),
+    handler: str = typer.Option(..., "--handler", help="Handler (e.g. handler.handler)"),
+    code: str = typer.Option(..., "--code", help="JSON code configuration"),
+    timeout: int = typer.Option(30, "--timeout", help="Timeout in seconds"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create a Lambda function."""
+    asyncio.run(_create_function(function_name, runtime, handler, code, timeout, port))
+
+
+async def _create_function(
+    function_name: str, runtime: str, handler: str, code_json: str, timeout: int, port: int
+) -> None:
+    client = _client(port)
+    try:
+        parsed_code = json.loads(code_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --code: {exc}")
+    json_body = json.dumps(
+        {
+            "FunctionName": function_name,
+            "Runtime": runtime,
+            "Handler": handler,
+            "Code": parsed_code,
+            "Timeout": timeout,
+        }
+    ).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            "/2015-03-31/functions",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("create-event-source-mapping")
+def create_event_source_mapping(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    event_source_arn: str = typer.Option(..., "--event-source-arn", help="Event source ARN"),
+    batch_size: int = typer.Option(10, "--batch-size", help="Batch size"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Create an event source mapping."""
+    asyncio.run(_create_event_source_mapping(function_name, event_source_arn, batch_size, port))
+
+
+async def _create_event_source_mapping(
+    function_name: str, event_source_arn: str, batch_size: int, port: int
+) -> None:
+    client = _client(port)
+    json_body = json.dumps(
+        {
+            "EventSourceArn": event_source_arn,
+            "FunctionName": function_name,
+            "BatchSize": batch_size,
+        }
+    ).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "POST",
+            "/2015-03-31/event-source-mappings",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("list-event-source-mappings")
+def list_event_source_mappings(
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List event source mappings."""
+    asyncio.run(_list_event_source_mappings(port))
+
+
+async def _list_event_source_mappings(port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            "/2015-03-31/event-source-mappings",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-event-source-mapping")
+def delete_event_source_mapping(
+    uuid: str = typer.Option(..., "--uuid", help="Event source mapping UUID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete an event source mapping."""
+    asyncio.run(_delete_event_source_mapping(uuid, port))
+
+
+async def _delete_event_source_mapping(uuid: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/2015-03-31/event-source-mappings/{uuid}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("get-function")
+def get_function(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get a Lambda function."""
+    asyncio.run(_get_function(function_name, port))
+
+
+async def _get_function(function_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            f"/2015-03-31/functions/{function_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("delete-function")
+def delete_function(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a Lambda function."""
+    asyncio.run(_delete_function(function_name, port))
+
+
+async def _delete_function(function_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "DELETE",
+            f"/2015-03-31/functions/{function_name}",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json() if resp.content else {})
+
+
+@app.command("list-functions")
+def list_functions(
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List Lambda functions."""
+    asyncio.run(_list_functions(port))
+
+
+async def _list_functions(port: int) -> None:
+    client = _client(port)
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "GET",
+            "/2015-03-31/functions",
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("update-function-configuration")
+def update_function_configuration(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    timeout: int = typer.Option(None, "--timeout", help="Timeout in seconds"),
+    handler: str = typer.Option(None, "--handler", help="Handler"),
+    runtime: str = typer.Option(None, "--runtime", help="Runtime"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a Lambda function configuration."""
+    asyncio.run(_update_function_configuration(function_name, timeout, handler, runtime, port))
+
+
+async def _update_function_configuration(
+    function_name: str,
+    timeout: int | None,
+    handler: str | None,
+    runtime: str | None,
+    port: int,
+) -> None:
+    client = _client(port)
+    body: dict = {"FunctionName": function_name}
+    if timeout is not None:
+        body["Timeout"] = timeout
+    if handler is not None:
+        body["Handler"] = handler
+    if runtime is not None:
+        body["Runtime"] = runtime
+    json_body = json.dumps(body).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/2015-03-31/functions/{function_name}/configuration",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())
+
+
+@app.command("update-function-code")
+def update_function_code(
+    function_name: str = typer.Option(..., "--function-name", help="Function name"),
+    code: str = typer.Option(..., "--code", help="JSON code configuration"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a Lambda function code."""
+    asyncio.run(_update_function_code(function_name, code, port))
+
+
+async def _update_function_code(function_name: str, code_json: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_code = json.loads(code_json)
+    except json.JSONDecodeError as exc:
+        exit_with_error(f"Invalid JSON in --code: {exc}")
+    json_body = json.dumps(parsed_code).encode()
+    try:
+        resp = await client.rest_request(
+            _SERVICE,
+            "PUT",
+            f"/2015-03-31/functions/{function_name}/code",
+            body=json_body,
+            headers={"Content-Type": "application/json"},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(resp.json())

--- a/src/lws/cli/services/secretsmanager.py
+++ b/src/lws/cli/services/secretsmanager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -159,6 +160,151 @@ async def _list_secrets(port: int) -> None:
             _SERVICE,
             f"{_TARGET_PREFIX}.ListSecrets",
             {},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("update-secret")
+def update_secret(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    secret_string: str = typer.Option(None, "--secret-string", help="New secret string value"),
+    description: str = typer.Option(None, "--description", help="New description"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a secret."""
+    asyncio.run(_update_secret(secret_id, secret_string, description, port))
+
+
+async def _update_secret(
+    secret_id: str, secret_string: str | None, description: str | None, port: int
+) -> None:
+    client = _client(port)
+    try:
+        body: dict = {"SecretId": secret_id}
+        if secret_string is not None:
+            body["SecretString"] = secret_string
+        if description is not None:
+            body["Description"] = description
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.UpdateSecret",
+            body,
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("restore-secret")
+def restore_secret(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Restore a deleted secret."""
+    asyncio.run(_restore_secret(secret_id, port))
+
+
+async def _restore_secret(secret_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.RestoreSecret",
+            {"SecretId": secret_id},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("tag-resource")
+def tag_resource(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    tags: str = typer.Option(..., "--tags", help='JSON array of {"Key":"k","Value":"v"}'),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Tag a secret."""
+    asyncio.run(_tag_resource(secret_id, tags, port))
+
+
+async def _tag_resource(secret_id: str, tags: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_tags = json.loads(tags)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.TagResource",
+            {"SecretId": secret_id, "Tags": parsed_tags},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("untag-resource")
+def untag_resource(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag keys"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Untag a secret."""
+    asyncio.run(_untag_resource(secret_id, tag_keys, port))
+
+
+async def _untag_resource(secret_id: str, tag_keys: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_keys = json.loads(tag_keys)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.UntagResource",
+            {"SecretId": secret_id, "TagKeys": parsed_keys},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-secret-version-ids")
+def list_secret_version_ids(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List version IDs for a secret."""
+    asyncio.run(_list_secret_version_ids(secret_id, port))
+
+
+async def _list_secret_version_ids(secret_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListSecretVersionIds",
+            {"SecretId": secret_id},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("get-resource-policy")
+def get_resource_policy(
+    secret_id: str = typer.Option(..., "--secret-id", help="Secret name or ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get the resource policy for a secret."""
+    asyncio.run(_get_resource_policy(secret_id, port))
+
+
+async def _get_resource_policy(secret_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.GetResourcePolicy",
+            {"SecretId": secret_id},
         )
     except Exception as exc:
         exit_with_error(str(exc))

--- a/src/lws/cli/services/sns.py
+++ b/src/lws/cli/services/sns.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -147,4 +148,216 @@ async def _subscribe(topic_arn: str, protocol: str, endpoint: str, port: int) ->
         )
     except Exception as exc:
         exit_with_error(str(exc))
+    output_json(xml_to_dict(xml))
+
+
+@app.command("unsubscribe")
+def unsubscribe(
+    subscription_arn: str = typer.Option(..., "--subscription-arn", help="Subscription ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Unsubscribe from a topic."""
+    asyncio.run(_unsubscribe(subscription_arn, port))
+
+
+async def _unsubscribe(subscription_arn: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "Unsubscribe", "SubscriptionArn": subscription_arn},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("get-topic-attributes")
+def get_topic_attributes(
+    topic_arn: str = typer.Option(..., "--topic-arn", help="Topic ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get topic attributes."""
+    asyncio.run(_get_topic_attributes(topic_arn, port))
+
+
+async def _get_topic_attributes(topic_arn: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "GetTopicAttributes", "TopicArn": topic_arn},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("set-topic-attributes")
+def set_topic_attributes(
+    topic_arn: str = typer.Option(..., "--topic-arn", help="Topic ARN"),
+    attribute_name: str = typer.Option(..., "--attribute-name", help="Attribute name"),
+    attribute_value: str = typer.Option(..., "--attribute-value", help="Attribute value"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Set a topic attribute."""
+    asyncio.run(_set_topic_attributes(topic_arn, attribute_name, attribute_value, port))
+
+
+async def _set_topic_attributes(
+    topic_arn: str, attribute_name: str, attribute_value: str, port: int
+) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {
+            "Action": "SetTopicAttributes",
+            "TopicArn": topic_arn,
+            "AttributeName": attribute_name,
+            "AttributeValue": attribute_value,
+        },
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("list-tags-for-resource")
+def list_tags_for_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List tags for a resource."""
+    asyncio.run(_list_tags_for_resource(resource_arn, port))
+
+
+async def _list_tags_for_resource(resource_arn: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "ListTagsForResource", "ResourceArn": resource_arn},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("tag-resource")
+def tag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    tags: str = typer.Option(..., "--tags", help="JSON array of tag objects"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Tag a resource."""
+    asyncio.run(_tag_resource(resource_arn, tags, port))
+
+
+async def _tag_resource(resource_arn: str, tags: str, port: int) -> None:
+    client = _client(port)
+    params: dict[str, str] = {
+        "Action": "TagResource",
+        "ResourceArn": resource_arn,
+    }
+    tag_list = json.loads(tags)
+    for i, tag in enumerate(tag_list, start=1):
+        params[f"Tags.member.{i}.Key"] = tag["Key"]
+        params[f"Tags.member.{i}.Value"] = tag["Value"]
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("untag-resource")
+def untag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="Resource ARN"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag keys"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Remove tags from a resource."""
+    asyncio.run(_untag_resource(resource_arn, tag_keys, port))
+
+
+async def _untag_resource(resource_arn: str, tag_keys: str, port: int) -> None:
+    client = _client(port)
+    params: dict[str, str] = {
+        "Action": "UntagResource",
+        "ResourceArn": resource_arn,
+    }
+    keys = json.loads(tag_keys)
+    for i, key in enumerate(keys, start=1):
+        params[f"TagKeys.member.{i}"] = key
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("get-subscription-attributes")
+def get_subscription_attributes(
+    subscription_arn: str = typer.Option(..., "--subscription-arn", help="Subscription ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get subscription attributes."""
+    asyncio.run(_get_subscription_attributes(subscription_arn, port))
+
+
+async def _get_subscription_attributes(subscription_arn: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "GetSubscriptionAttributes", "SubscriptionArn": subscription_arn},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("set-subscription-attributes")
+def set_subscription_attributes(
+    subscription_arn: str = typer.Option(..., "--subscription-arn", help="Subscription ARN"),
+    attribute_name: str = typer.Option(..., "--attribute-name", help="Attribute name"),
+    attribute_value: str = typer.Option(..., "--attribute-value", help="Attribute value"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Set a subscription attribute."""
+    asyncio.run(
+        _set_subscription_attributes(subscription_arn, attribute_name, attribute_value, port)
+    )
+
+
+async def _set_subscription_attributes(
+    subscription_arn: str, attribute_name: str, attribute_value: str, port: int
+) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {
+            "Action": "SetSubscriptionAttributes",
+            "SubscriptionArn": subscription_arn,
+            "AttributeName": attribute_name,
+            "AttributeValue": attribute_value,
+        },
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("confirm-subscription")
+def confirm_subscription(
+    topic_arn: str = typer.Option(..., "--topic-arn", help="Topic ARN"),
+    token: str = typer.Option(..., "--token", help="Subscription confirmation token"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Confirm a subscription."""
+    asyncio.run(_confirm_subscription(topic_arn, token, port))
+
+
+async def _confirm_subscription(topic_arn: str, token: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "ConfirmSubscription", "TopicArn": topic_arn, "Token": token},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("list-subscriptions-by-topic")
+def list_subscriptions_by_topic(
+    topic_arn: str = typer.Option(..., "--topic-arn", help="Topic ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List subscriptions for a topic."""
+    asyncio.run(_list_subscriptions_by_topic(topic_arn, port))
+
+
+async def _list_subscriptions_by_topic(topic_arn: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "ListSubscriptionsByTopic", "TopicArn": topic_arn},
+    )
     output_json(xml_to_dict(xml))

--- a/src/lws/cli/services/sqs.py
+++ b/src/lws/cli/services/sqs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -208,4 +209,287 @@ async def _purge_queue(queue_name: str, port: int) -> None:
         )
     except Exception as exc:
         exit_with_error(str(exc))
+    output_json(xml_to_dict(xml))
+
+
+@app.command("get-queue-url")
+def get_queue_url(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get the URL of a queue."""
+    asyncio.run(_get_queue_url(queue_name, port))
+
+
+async def _get_queue_url(queue_name: str, port: int) -> None:
+    client = _client(port)
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "GetQueueUrl", "QueueName": queue_name},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("set-queue-attributes")
+def set_queue_attributes(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    attributes: str = typer.Option(..., "--attributes", help="JSON object of attributes"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Set attributes on a queue."""
+    asyncio.run(_set_queue_attributes(queue_name, attributes, port))
+
+
+async def _set_queue_attributes(queue_name: str, attributes: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "SetQueueAttributes",
+        "QueueUrl": queue_url,
+    }
+    attrs = json.loads(attributes)
+    for i, (key, value) in enumerate(attrs.items(), start=1):
+        params[f"Attribute.{i}.Name"] = key
+        params[f"Attribute.{i}.Value"] = value
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("send-message-batch")
+def send_message_batch(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    entries: str = typer.Option(..., "--entries", help="JSON array of entries"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Send a batch of messages to a queue."""
+    asyncio.run(_send_message_batch(queue_name, entries, port))
+
+
+async def _send_message_batch(queue_name: str, entries: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "SendMessageBatch",
+        "QueueUrl": queue_url,
+    }
+    items = json.loads(entries)
+    for i, entry in enumerate(items, start=1):
+        params[f"SendMessageBatchRequestEntry.{i}.Id"] = entry["Id"]
+        params[f"SendMessageBatchRequestEntry.{i}.MessageBody"] = entry["MessageBody"]
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("delete-message-batch")
+def delete_message_batch(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    entries: str = typer.Option(..., "--entries", help="JSON array of entries"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete a batch of messages from a queue."""
+    asyncio.run(_delete_message_batch(queue_name, entries, port))
+
+
+async def _delete_message_batch(queue_name: str, entries: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "DeleteMessageBatch",
+        "QueueUrl": queue_url,
+    }
+    items = json.loads(entries)
+    for i, entry in enumerate(items, start=1):
+        params[f"DeleteMessageBatchRequestEntry.{i}.Id"] = entry["Id"]
+        params[f"DeleteMessageBatchRequestEntry.{i}.ReceiptHandle"] = entry["ReceiptHandle"]
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("change-message-visibility")
+def change_message_visibility(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    receipt_handle: str = typer.Option(..., "--receipt-handle", help="Receipt handle"),
+    visibility_timeout: int = typer.Option(..., "--visibility-timeout", help="Visibility timeout"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Change the visibility timeout of a message."""
+    asyncio.run(_change_message_visibility(queue_name, receipt_handle, visibility_timeout, port))
+
+
+async def _change_message_visibility(
+    queue_name: str, receipt_handle: str, visibility_timeout: int, port: int
+) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    xml = await client.form_request(
+        _SERVICE,
+        {
+            "Action": "ChangeMessageVisibility",
+            "QueueUrl": queue_url,
+            "ReceiptHandle": receipt_handle,
+            "VisibilityTimeout": str(visibility_timeout),
+        },
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("change-message-visibility-batch")
+def change_message_visibility_batch(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    entries: str = typer.Option(..., "--entries", help="JSON array of entries"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Change visibility timeout for a batch of messages."""
+    asyncio.run(_change_message_visibility_batch(queue_name, entries, port))
+
+
+async def _change_message_visibility_batch(queue_name: str, entries: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "ChangeMessageVisibilityBatch",
+        "QueueUrl": queue_url,
+    }
+    items = json.loads(entries)
+    for i, entry in enumerate(items, start=1):
+        params[f"ChangeMessageVisibilityBatchRequestEntry.{i}.Id"] = entry["Id"]
+        params[f"ChangeMessageVisibilityBatchRequestEntry.{i}.ReceiptHandle"] = entry[
+            "ReceiptHandle"
+        ]
+        params[f"ChangeMessageVisibilityBatchRequestEntry.{i}.VisibilityTimeout"] = str(
+            entry["VisibilityTimeout"]
+        )
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("list-queue-tags")
+def list_queue_tags(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List tags on a queue."""
+    asyncio.run(_list_queue_tags(queue_name, port))
+
+
+async def _list_queue_tags(queue_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "ListQueueTags", "QueueUrl": queue_url},
+    )
+    output_json(xml_to_dict(xml))
+
+
+@app.command("tag-queue")
+def tag_queue(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    tags: str = typer.Option(..., "--tags", help="JSON object of tags"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Tag a queue."""
+    asyncio.run(_tag_queue(queue_name, tags, port))
+
+
+async def _tag_queue(queue_name: str, tags: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "TagQueue",
+        "QueueUrl": queue_url,
+    }
+    tag_dict = json.loads(tags)
+    for i, (key, value) in enumerate(tag_dict.items(), start=1):
+        params[f"Tag.{i}.Key"] = key
+        params[f"Tag.{i}.Value"] = value
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("untag-queue")
+def untag_queue(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag keys"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Remove tags from a queue."""
+    asyncio.run(_untag_queue(queue_name, tag_keys, port))
+
+
+async def _untag_queue(queue_name: str, tag_keys: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    params: dict[str, str] = {
+        "Action": "UntagQueue",
+        "QueueUrl": queue_url,
+    }
+    keys = json.loads(tag_keys)
+    for i, key in enumerate(keys, start=1):
+        params[f"TagKey.{i}"] = key
+    xml = await client.form_request(_SERVICE, params)
+    output_json(xml_to_dict(xml))
+
+
+@app.command("list-dead-letter-source-queues")
+def list_dead_letter_source_queues(
+    queue_name: str = typer.Option(..., "--queue-name", help="Queue name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List dead-letter source queues."""
+    asyncio.run(_list_dead_letter_source_queues(queue_name, port))
+
+
+async def _list_dead_letter_source_queues(queue_name: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, queue_name)
+        queue_url = resource.get("queue_url", "")
+    except Exception:
+        svc_port = await client.service_port(_SERVICE)
+        queue_url = f"http://localhost:{svc_port}/000000000000/{queue_name}"
+    xml = await client.form_request(
+        _SERVICE,
+        {"Action": "ListDeadLetterSourceQueues", "QueueUrl": queue_url},
+    )
     output_json(xml_to_dict(xml))

--- a/src/lws/cli/services/ssm.py
+++ b/src/lws/cli/services/ssm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import typer
 
@@ -132,6 +133,134 @@ async def _describe_parameters(port: int) -> None:
             _SERVICE,
             f"{_TARGET_PREFIX}.DescribeParameters",
             {},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("get-parameters")
+def get_parameters(
+    names: str = typer.Option(..., "--names", help="JSON array of parameter names"),
+    with_decryption: bool = typer.Option(False, "--with-decryption", help="Decrypt SecureString"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get multiple parameters by name."""
+    asyncio.run(_get_parameters(names, with_decryption, port))
+
+
+async def _get_parameters(names: str, with_decryption: bool, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_names = json.loads(names)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.GetParameters",
+            {"Names": parsed_names, "WithDecryption": with_decryption},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("delete-parameters")
+def delete_parameters(
+    names: str = typer.Option(..., "--names", help="JSON array of parameter names"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Delete multiple parameters."""
+    asyncio.run(_delete_parameters(names, port))
+
+
+async def _delete_parameters(names: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_names = json.loads(names)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.DeleteParameters",
+            {"Names": parsed_names},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("add-tags-to-resource")
+def add_tags_to_resource(
+    resource_type: str = typer.Option(
+        ..., "--resource-type", help="Resource type (e.g. Parameter)"
+    ),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    tags: str = typer.Option(..., "--tags", help='JSON array of {"Key":"k","Value":"v"}'),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Add tags to a resource."""
+    asyncio.run(_add_tags_to_resource(resource_type, resource_id, tags, port))
+
+
+async def _add_tags_to_resource(resource_type: str, resource_id: str, tags: str, port: int) -> None:
+    client = _client(port)
+    try:
+        parsed_tags = json.loads(tags)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.AddTagsToResource",
+            {"ResourceType": resource_type, "ResourceId": resource_id, "Tags": parsed_tags},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("remove-tags-from-resource")
+def remove_tags_from_resource(
+    resource_type: str = typer.Option(
+        ..., "--resource-type", help="Resource type (e.g. Parameter)"
+    ),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag keys"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Remove tags from a resource."""
+    asyncio.run(_remove_tags_from_resource(resource_type, resource_id, tag_keys, port))
+
+
+async def _remove_tags_from_resource(
+    resource_type: str, resource_id: str, tag_keys: str, port: int
+) -> None:
+    client = _client(port)
+    try:
+        parsed_keys = json.loads(tag_keys)
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.RemoveTagsFromResource",
+            {"ResourceType": resource_type, "ResourceId": resource_id, "TagKeys": parsed_keys},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-tags-for-resource")
+def list_tags_for_resource(
+    resource_type: str = typer.Option(
+        ..., "--resource-type", help="Resource type (e.g. Parameter)"
+    ),
+    resource_id: str = typer.Option(..., "--resource-id", help="Resource ID"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List tags for a resource."""
+    asyncio.run(_list_tags_for_resource(resource_type, resource_id, port))
+
+
+async def _list_tags_for_resource(resource_type: str, resource_id: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListTagsForResource",
+            {"ResourceType": resource_type, "ResourceId": resource_id},
         )
     except Exception as exc:
         exit_with_error(str(exc))

--- a/src/lws/cli/services/stepfunctions.py
+++ b/src/lws/cli/services/stepfunctions.py
@@ -6,7 +6,13 @@ import asyncio
 
 import typer
 
-from lws.cli.services.client import LwsClient, exit_with_error, output_json
+from lws.cli.services.client import (
+    LwsClient,
+    exit_with_error,
+    json_request_output,
+    output_json,
+    parse_json_option,
+)
 
 app = typer.Typer(help="Step Functions commands")
 
@@ -186,3 +192,189 @@ async def _describe_state_machine(name: str, port: int) -> None:
     except Exception as exc:
         exit_with_error(str(exc))
     output_json(result)
+
+
+@app.command("start-sync-execution")
+def start_sync_execution(
+    name: str = typer.Option(..., "--name", help="State machine name"),
+    execution_input: str = typer.Option("{}", "--input", help="JSON input"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Start a synchronous state machine execution."""
+    asyncio.run(_start_sync_execution(name, execution_input, port))
+
+
+async def _start_sync_execution(name: str, input_str: str, port: int) -> None:
+    client = _client(port)
+    try:
+        resource = await client.resolve_resource(_SERVICE, name)
+        arn = resource.get("arn", f"arn:aws:states:us-east-1:000000000000:stateMachine:{name}")
+    except Exception:
+        arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{name}"
+    result = await client.json_target_request(
+        _SERVICE,
+        f"{_TARGET_PREFIX}.StartSyncExecution",
+        {"stateMachineArn": arn, "input": input_str},
+    )
+    output_json(result)
+
+
+@app.command("stop-execution")
+def stop_execution(
+    execution_arn: str = typer.Option(..., "--execution-arn", help="Execution ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Stop a state machine execution."""
+    asyncio.run(_stop_execution(execution_arn, port))
+
+
+async def _stop_execution(execution_arn: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.StopExecution",
+            {"executionArn": execution_arn},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("update-state-machine")
+def update_state_machine(
+    name: str = typer.Option(..., "--name", help="State machine name"),
+    definition: str = typer.Option(..., "--definition", help="ASL definition JSON"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Update a state machine."""
+    asyncio.run(_update_state_machine(name, definition, port))
+
+
+async def _update_state_machine(name: str, definition: str, port: int) -> None:
+    client = _client(port)
+    arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{name}"
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.UpdateStateMachine",
+            {"stateMachineArn": arn, "definition": definition},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("get-execution-history")
+def get_execution_history(
+    execution_arn: str = typer.Option(..., "--execution-arn", help="Execution ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Get execution history."""
+    asyncio.run(_get_execution_history(execution_arn, port))
+
+
+async def _get_execution_history(execution_arn: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.GetExecutionHistory",
+            {"executionArn": execution_arn},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("validate-state-machine-definition")
+def validate_state_machine_definition(
+    definition: str = typer.Option(..., "--definition", help="ASL definition JSON"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Validate a state machine definition."""
+    asyncio.run(_validate_state_machine_definition(definition, port))
+
+
+async def _validate_state_machine_definition(definition: str, port: int) -> None:
+    client = _client(port)
+    try:
+        result = await client.json_target_request(
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ValidateStateMachineDefinition",
+            {"definition": definition},
+        )
+    except Exception as exc:
+        exit_with_error(str(exc))
+    output_json(result)
+
+
+@app.command("list-state-machine-versions")
+def list_state_machine_versions(
+    name: str = typer.Option(..., "--name", help="State machine name"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List state machine versions."""
+    asyncio.run(_list_state_machine_versions(name, port))
+
+
+async def _list_state_machine_versions(name: str, port: int) -> None:
+    arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{name}"
+    await json_request_output(
+        port,
+        _SERVICE,
+        f"{_TARGET_PREFIX}.ListStateMachineVersions",
+        {"stateMachineArn": arn},
+    )
+
+
+@app.command("tag-resource")
+def tag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="State machine or activity ARN"),
+    tags: str = typer.Option(..., "--tags", help="JSON array of key/value tag objects"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Tag a Step Functions resource."""
+    parsed_tags = parse_json_option(tags, "--tags")
+    asyncio.run(
+        json_request_output(
+            port,
+            _SERVICE,
+            f"{_TARGET_PREFIX}.TagResource",
+            {"resourceArn": resource_arn, "tags": parsed_tags},
+        )
+    )
+
+
+@app.command("untag-resource")
+def untag_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="State machine or activity ARN"),
+    tag_keys: str = typer.Option(..., "--tag-keys", help="JSON array of tag key strings to remove"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """Untag a Step Functions resource."""
+    parsed_keys = parse_json_option(tag_keys, "--tag-keys")
+    asyncio.run(
+        json_request_output(
+            port,
+            _SERVICE,
+            f"{_TARGET_PREFIX}.UntagResource",
+            {"resourceArn": resource_arn, "tagKeys": parsed_keys},
+        )
+    )
+
+
+@app.command("list-tags-for-resource")
+def list_tags_for_resource(
+    resource_arn: str = typer.Option(..., "--resource-arn", help="State machine or activity ARN"),
+    port: int = typer.Option(3000, "--port", "-p", help="LDK port"),
+) -> None:
+    """List tags for a Step Functions resource."""
+    asyncio.run(
+        json_request_output(
+            port,
+            _SERVICE,
+            f"{_TARGET_PREFIX}.ListTagsForResource",
+            {"resourceArn": resource_arn},
+        )
+    )

--- a/src/lws/parser/template_parser.py
+++ b/src/lws/parser/template_parser.py
@@ -56,6 +56,16 @@ class DynamoTableProps:
 
 
 @dataclass
+class EventSourceMappingProps:
+    """Subset of ``AWS::Lambda::EventSourceMapping`` properties."""
+
+    function_name: Any = None
+    event_source_arn: Any = None
+    batch_size: int = 10
+    enabled: bool = True
+
+
+@dataclass
 class ApiGatewayRouteProps:
     """A single API Gateway route (v1 or v2)."""
 
@@ -138,6 +148,27 @@ def extract_dynamo_tables(resources: list[CfnResource]) -> list[DynamoTableProps
                 key_schema=props.get("KeySchema", []),
                 attribute_definitions=props.get("AttributeDefinitions", []),
                 gsi_definitions=props.get("GlobalSecondaryIndexes", []),
+            )
+        )
+    return results
+
+
+def extract_event_source_mappings(
+    resources: list[CfnResource],
+) -> list[EventSourceMappingProps]:
+    """Pull Lambda event source mappings out of the resource list."""
+    results: list[EventSourceMappingProps] = []
+    for r in resources:
+        if r.resource_type != "AWS::Lambda::EventSourceMapping":
+            continue
+        props = r.properties
+        enabled = props.get("Enabled", True)
+        results.append(
+            EventSourceMappingProps(
+                function_name=props.get("FunctionName"),
+                event_source_arn=props.get("EventSourceArn"),
+                batch_size=props.get("BatchSize", 10),
+                enabled=enabled if isinstance(enabled, bool) else True,
             )
         )
     return results

--- a/src/lws/providers/apigateway/routes.py
+++ b/src/lws/providers/apigateway/routes.py
@@ -462,11 +462,11 @@ class ApiGatewayManagementRouter:
 
     # -- Integration responses -----------------------------------------------
 
-    async def _put_integration_response(
+    async def _put_integration_response(  # pylint: disable=unused-argument
         self,
-        _rest_api_id: str,
-        _resource_id: str,
-        _http_method: str,
+        rest_api_id: str,
+        resource_id: str,
+        http_method: str,
         status_code: str,
         request: Request,
     ) -> Response:
@@ -478,22 +478,22 @@ class ApiGatewayManagementRouter:
         }
         return _json_response(resp_data, 201)
 
-    async def _get_integration_response(
+    async def _get_integration_response(  # pylint: disable=unused-argument
         self,
-        _rest_api_id: str,
-        _resource_id: str,
-        _http_method: str,
+        rest_api_id: str,
+        resource_id: str,
+        http_method: str,
         status_code: str,
     ) -> Response:
         return _json_response({"statusCode": status_code})
 
     # -- Method responses ----------------------------------------------------
 
-    async def _put_method_response(
+    async def _put_method_response(  # pylint: disable=unused-argument
         self,
-        _rest_api_id: str,
-        _resource_id: str,
-        _http_method: str,
+        rest_api_id: str,
+        resource_id: str,
+        http_method: str,
         status_code: str,
         request: Request,
     ) -> Response:
@@ -505,11 +505,11 @@ class ApiGatewayManagementRouter:
         }
         return _json_response(resp_data, 201)
 
-    async def _get_method_response(
+    async def _get_method_response(  # pylint: disable=unused-argument
         self,
-        _rest_api_id: str,
-        _resource_id: str,
-        _http_method: str,
+        rest_api_id: str,
+        resource_id: str,
+        http_method: str,
         status_code: str,
     ) -> Response:
         return _json_response({"statusCode": status_code})

--- a/src/lws/providers/lambda_runtime/event_source_manager.py
+++ b/src/lws/providers/lambda_runtime/event_source_manager.py
@@ -1,0 +1,162 @@
+"""EventSourceManager — activates event source mappings at runtime.
+
+Coordinates between queue providers (SQS) and stream dispatchers
+(DynamoDB Streams) to invoke Lambda functions when events arrive.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from lws.interfaces.compute import ICompute
+from lws.interfaces.queue import IQueue
+from lws.providers._shared.lambda_helpers import build_default_lambda_context
+from lws.providers.dynamodb.streams import StreamDispatcher
+from lws.providers.sqs.event_source import EventSourceMapping, SqsEventSourcePoller
+
+logger = logging.getLogger(__name__)
+
+
+class EventSourceManager:
+    """Manages activation and deactivation of event source mappings.
+
+    Parameters
+    ----------
+    queue_providers : dict[str, IQueue]
+        Map of queue name to IQueue provider.
+    stream_dispatchers : dict[str, StreamDispatcher]
+        Map of table name to StreamDispatcher.
+    compute_providers : dict[str, ICompute]
+        Map of function name to ICompute provider.
+    """
+
+    def __init__(
+        self,
+        queue_providers: dict[str, IQueue],
+        stream_dispatchers: dict[str, StreamDispatcher],
+        compute_providers: dict[str, ICompute],
+    ) -> None:
+        self._queue_providers = queue_providers
+        self._stream_dispatchers = stream_dispatchers
+        self._compute_providers = compute_providers
+        self._active_pollers: dict[str, SqsEventSourcePoller] = {}
+        self._active_stream_handlers: dict[str, tuple[str, Any]] = {}
+
+    async def activate(self, mapping: dict[str, Any]) -> None:
+        """Activate an event source mapping based on its EventSourceArn."""
+        esm_uuid = mapping.get("UUID", "")
+        event_source_arn = mapping.get("EventSourceArn", "")
+        function_ref = mapping.get("FunctionArn", "") or mapping.get("FunctionName", "")
+        batch_size = mapping.get("BatchSize", 10)
+
+        # Extract function name from ARN if needed
+        function_name = _extract_function_name(function_ref)
+
+        if ":sqs:" in event_source_arn:
+            await self._activate_sqs(esm_uuid, event_source_arn, function_name, batch_size)
+        elif ":dynamodb:" in event_source_arn and "/stream" in event_source_arn:
+            self._activate_dynamodb_stream(esm_uuid, event_source_arn, function_name)
+        else:
+            logger.warning("Unsupported event source ARN: %s", event_source_arn)
+
+    async def deactivate(self, esm_uuid: str) -> None:
+        """Deactivate an event source mapping by UUID."""
+        if esm_uuid in self._active_pollers:
+            poller = self._active_pollers.pop(esm_uuid)
+            await poller.stop()
+            logger.info("Stopped SQS poller for mapping %s", esm_uuid)
+
+        if esm_uuid in self._active_stream_handlers:
+            self._active_stream_handlers.pop(esm_uuid)
+            logger.info("Removed stream handler for mapping %s", esm_uuid)
+
+    async def stop_all(self) -> None:
+        """Stop all active pollers and handlers."""
+        for esm_uuid in list(self._active_pollers):
+            poller = self._active_pollers.pop(esm_uuid)
+            await poller.stop()
+        self._active_stream_handlers.clear()
+
+    async def _activate_sqs(
+        self,
+        esm_uuid: str,
+        event_source_arn: str,
+        function_name: str,
+        batch_size: int,
+    ) -> None:
+        """Activate an SQS event source mapping."""
+        queue_name = _extract_queue_name(event_source_arn)
+        queue_provider = self._queue_providers.get(queue_name)
+        if queue_provider is None:
+            logger.warning("Queue provider not found for %s", queue_name)
+            return
+
+        compute = self._compute_providers.get(function_name)
+        if compute is None:
+            logger.warning("Compute provider not found for %s", function_name)
+            return
+
+        mapping = EventSourceMapping(
+            queue_name=queue_name,
+            function_name=function_name,
+            batch_size=batch_size,
+        )
+        poller = SqsEventSourcePoller(
+            queue_provider=queue_provider,
+            compute_providers={function_name: compute},
+            mappings=[mapping],
+        )
+        await poller.start()
+        self._active_pollers[esm_uuid] = poller
+        logger.info("Activated SQS event source: %s -> %s", queue_name, function_name)
+
+    def _activate_dynamodb_stream(
+        self,
+        esm_uuid: str,
+        event_source_arn: str,
+        function_name: str,
+    ) -> None:
+        """Activate a DynamoDB Streams event source mapping."""
+        table_name = _extract_table_name(event_source_arn)
+        dispatcher = self._stream_dispatchers.get(table_name)
+        if dispatcher is None:
+            logger.warning("Stream dispatcher not found for table %s", table_name)
+            return
+
+        compute = self._compute_providers.get(function_name)
+        if compute is None:
+            logger.warning("Compute provider not found for %s", function_name)
+            return
+
+        async def handler(event: dict) -> None:
+            context = build_default_lambda_context(function_name)
+            await compute.invoke(event, context)
+
+        dispatcher.register_handler(table_name, handler)
+        self._active_stream_handlers[esm_uuid] = (table_name, handler)
+        logger.info("Activated DynamoDB stream: %s -> %s", table_name, function_name)
+
+
+def _extract_function_name(function_ref: str) -> str:
+    """Extract function name from an ARN or return the string as-is."""
+    if function_ref.startswith("arn:"):
+        parts = function_ref.split(":")
+        return parts[-1] if parts else function_ref
+    return function_ref
+
+
+def _extract_queue_name(arn: str) -> str:
+    """Extract queue name from an SQS ARN."""
+    # arn:aws:sqs:region:account:queue-name
+    parts = arn.split(":")
+    return parts[-1] if len(parts) >= 6 else arn
+
+
+def _extract_table_name(arn: str) -> str:
+    """Extract table name from a DynamoDB Streams ARN."""
+    # arn:aws:dynamodb:region:account:table/TABLE_NAME/stream/...
+    if "table/" in arn:
+        after_table = arn.split("table/", 1)[1]
+        return after_table.split("/")[0]
+    return arn

--- a/src/lws/providers/lambda_runtime/routes.py
+++ b/src/lws/providers/lambda_runtime/routes.py
@@ -596,7 +596,8 @@ class LambdaManagementRouter:
         return _json_response(mapping, 202)
 
     async def _list_event_source_mappings(self, _request: Request) -> Response:
-        return _json_response({"EventSourceMappings": []})
+        mappings = list(self._state.event_source_mappings.values())
+        return _json_response({"EventSourceMappings": mappings})
 
     # -- Other stubs ---------------------------------------------------------
 

--- a/tests/architecture/tests/e2e/test_no_httpx_imports.py
+++ b/tests/architecture/tests/e2e/test_no_httpx_imports.py
@@ -1,0 +1,45 @@
+"""Architecture test: E2E test files must not import httpx.
+
+E2E tests exercise the full stack through the ``lws`` CLI (via ``CliRunner``,
+``lws_invoke``, ``assert_invoke``).  Direct ``httpx`` usage bypasses the CLI
+layer and should be replaced with CLI commands.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+E2E_DIR = Path(__file__).parent.parent.parent.parent / "e2e"
+
+
+def _find_httpx_imports(filepath: Path) -> list[int]:
+    """Return line numbers of httpx imports in a Python file."""
+    tree = ast.parse(filepath.read_text())
+    lines = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "httpx" or alias.name.startswith("httpx."):
+                    lines.append(node.lineno)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "httpx" or node.module.startswith("httpx."):
+                lines.append(node.lineno)
+    return lines
+
+
+class TestNoHttpxImports:
+    def test_e2e_test_files_do_not_import_httpx(self):
+        # Arrange
+        violations = []
+        for path in sorted(E2E_DIR.rglob("test_*.py")):
+            lines = _find_httpx_imports(path)
+            if lines:
+                rel = path.relative_to(E2E_DIR)
+                violations.append(f"{rel} (lines {lines})")
+
+        # Assert
+        assert violations == [], (
+            "E2E test files must not import httpx. "
+            "Use the lws CLI (via CliRunner) instead.\n" + "\n".join(f"  - {v}" for v in violations)
+        )

--- a/tests/e2e/apigateway/test_create_deployment.py
+++ b/tests/e2e/apigateway/test_create_deployment.py
@@ -1,0 +1,41 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateDeployment:
+    def test_create_deployment(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-create-deployment",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "id" in body

--- a/tests/e2e/apigateway/test_create_resource.py
+++ b/tests/e2e/apigateway/test_create_resource.py
@@ -1,0 +1,48 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateResource:
+    def test_create_resource(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-create-resource",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "items",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_path = "/items"
+        actual_path = body["path"]
+        assert actual_path == expected_path

--- a/tests/e2e/apigateway/test_create_rest_api.py
+++ b/tests/e2e/apigateway/test_create_rest_api.py
@@ -1,0 +1,32 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateRestApi:
+    def test_create_rest_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        api_name = "e2e-create-rest-api"
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                api_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "id" in body
+        assert body["name"] == api_name

--- a/tests/e2e/apigateway/test_create_stage.py
+++ b/tests/e2e/apigateway/test_create_stage.py
@@ -1,0 +1,58 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateStage:
+    def test_create_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-create-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        deployment = lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        deployment_id = deployment["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "create-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "e2e-dev",
+                "--deployment-id",
+                deployment_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-dev"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/apigateway/test_delete_integration.py
+++ b/tests/e2e/apigateway/test_delete_integration.py
@@ -1,0 +1,87 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteIntegration:
+    def test_delete_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-delete-integration",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "remove",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "POST",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "POST",
+                "--type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "delete-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "POST",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_delete_method.py
+++ b/tests/e2e/apigateway/test_delete_method.py
@@ -1,0 +1,71 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteMethod:
+    def test_delete_method(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-delete-method",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "temp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "DELETE",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "delete-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "DELETE",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_delete_resource.py
+++ b/tests/e2e/apigateway/test_delete_resource.py
@@ -1,0 +1,55 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteResource:
+    def test_delete_resource(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-delete-resource",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "to-delete",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "delete-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_delete_rest_api.py
+++ b/tests/e2e/apigateway/test_delete_rest_api.py
@@ -1,0 +1,37 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteRestApi:
+    def test_delete_rest_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-delete-rest-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "delete-rest-api",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_delete_stage.py
+++ b/tests/e2e/apigateway/test_delete_stage.py
@@ -1,0 +1,64 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteStage:
+    def test_delete_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-delete-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        deployment = lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        deployment_id = deployment["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "create-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "to-delete",
+                "--deployment-id",
+                deployment_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "delete-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "to-delete",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_get_deployment.py
+++ b/tests/e2e/apigateway/test_get_deployment.py
@@ -1,0 +1,56 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetDeployment:
+    def test_get_deployment(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-deployment",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        deployment = lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        deployment_id = deployment["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--deployment-id",
+                deployment_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_id = deployment_id
+        actual_id = body["id"]
+        assert actual_id == expected_id

--- a/tests/e2e/apigateway/test_get_integration.py
+++ b/tests/e2e/apigateway/test_get_integration.py
@@ -1,0 +1,93 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetIntegration:
+    def test_get_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-integration",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "data",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_type = "AWS_PROXY"
+        actual_type = body["type"]
+        assert actual_type == expected_type

--- a/tests/e2e/apigateway/test_get_integration_response.py
+++ b/tests/e2e/apigateway/test_get_integration_response.py
@@ -1,0 +1,111 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetIntegrationResponse:
+    def test_get_integration_response(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-int-resp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "getresp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--type",
+                "MOCK",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-integration-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-integration-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_status_code = "200"
+        actual_status_code = body["statusCode"]
+        assert actual_status_code == expected_status_code

--- a/tests/e2e/apigateway/test_get_method.py
+++ b/tests/e2e/apigateway/test_get_method.py
@@ -1,0 +1,77 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetMethod:
+    def test_get_method(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-method",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "products",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_method = "GET"
+        actual_method = body["httpMethod"]
+        assert actual_method == expected_method

--- a/tests/e2e/apigateway/test_get_method_response.py
+++ b/tests/e2e/apigateway/test_get_method_response.py
@@ -1,0 +1,95 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetMethodResponse:
+    def test_get_method_response(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-method-resp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "gmresp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-method-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_status_code = "200"
+        actual_status_code = body["statusCode"]
+        assert actual_status_code == expected_status_code

--- a/tests/e2e/apigateway/test_get_resources.py
+++ b/tests/e2e/apigateway/test_get_resources.py
@@ -1,0 +1,42 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetResources:
+    def test_get_resources(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-resources",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-resources",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "item" in body
+        assert len(body["item"]) >= 1

--- a/tests/e2e/apigateway/test_get_rest_api.py
+++ b/tests/e2e/apigateway/test_get_rest_api.py
@@ -1,0 +1,43 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetRestApi:
+    def test_get_rest_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-rest-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-rest-api",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_name = "e2e-get-rest-api"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/e2e/apigateway/test_get_stage.py
+++ b/tests/e2e/apigateway/test_get_stage.py
@@ -1,0 +1,70 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetStage:
+    def test_get_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-get-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        deployment = lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        deployment_id = deployment["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "create-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "e2e-staging",
+                "--deployment-id",
+                deployment_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "get-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "e2e-staging",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-staging"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/apigateway/test_list_deployments.py
+++ b/tests/e2e/apigateway/test_list_deployments.py
@@ -1,0 +1,52 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListDeployments:
+    def test_list_deployments(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-list-deployments",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "list-deployments",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "item" in body
+        assert len(body["item"]) >= 1

--- a/tests/e2e/apigateway/test_list_rest_apis.py
+++ b/tests/e2e/apigateway/test_list_rest_apis.py
@@ -1,0 +1,38 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListRestApis:
+    def test_list_rest_apis(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-list-rest-apis",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "list-rest-apis",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "item" in body

--- a/tests/e2e/apigateway/test_put_integration.py
+++ b/tests/e2e/apigateway/test_put_integration.py
@@ -1,0 +1,79 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestPutIntegration:
+    def test_put_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-put-integration",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "items",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "POST",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "put-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "POST",
+                "--type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_type = "AWS_PROXY"
+        actual_type = body["type"]
+        assert actual_type == expected_type

--- a/tests/e2e/apigateway/test_put_integration_response.py
+++ b/tests/e2e/apigateway/test_put_integration_response.py
@@ -1,0 +1,95 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestPutIntegrationResponse:
+    def test_put_integration_response(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-put-int-resp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "resp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "apigateway",
+                "put-integration",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--type",
+                "MOCK",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "put-integration-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_status_code = "200"
+        actual_status_code = body["statusCode"]
+        assert actual_status_code == expected_status_code

--- a/tests/e2e/apigateway/test_put_method.py
+++ b/tests/e2e/apigateway/test_put_method.py
@@ -1,0 +1,63 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestPutMethod:
+    def test_put_method(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-put-method",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "orders",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_method = "GET"
+        actual_method = body["httpMethod"]
+        assert actual_method == expected_method

--- a/tests/e2e/apigateway/test_put_method_response.py
+++ b/tests/e2e/apigateway/test_put_method_response.py
@@ -1,0 +1,79 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestPutMethodResponse:
+    def test_put_method_response(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-put-method-resp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        root_resource_id = created["rootResourceId"]
+        resource = lws_invoke(
+            [
+                "apigateway",
+                "create-resource",
+                "--rest-api-id",
+                rest_api_id,
+                "--parent-id",
+                root_resource_id,
+                "--path-part",
+                "mresp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_id = resource["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "put-method",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "put-method-response",
+                "--rest-api-id",
+                rest_api_id,
+                "--resource-id",
+                resource_id,
+                "--http-method",
+                "GET",
+                "--status-code",
+                "200",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_status_code = "200"
+        actual_status_code = body["statusCode"]
+        assert actual_status_code == expected_status_code

--- a/tests/e2e/apigateway/test_update_rest_api.py
+++ b/tests/e2e/apigateway/test_update_rest_api.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUpdateRestApi:
+    def test_update_rest_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-update-rest-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        patch_ops = json.dumps([{"op": "replace", "path": "/name", "value": "e2e-updated"}])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "update-rest-api",
+                "--rest-api-id",
+                rest_api_id,
+                "--patch-operations",
+                patch_ops,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_name = "e2e-updated"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/e2e/apigateway/test_update_stage.py
+++ b/tests/e2e/apigateway/test_update_stage.py
@@ -1,0 +1,73 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUpdateStage:
+    def test_update_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "create-rest-api",
+                "--name",
+                "e2e-update-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        rest_api_id = created["id"]
+        deployment = lws_invoke(
+            [
+                "apigateway",
+                "create-deployment",
+                "--rest-api-id",
+                rest_api_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        deployment_id = deployment["id"]
+        lws_invoke(
+            [
+                "apigateway",
+                "create-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "e2e-prod",
+                "--deployment-id",
+                deployment_id,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        patch_ops = json.dumps([])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "update-stage",
+                "--rest-api-id",
+                rest_api_id,
+                "--stage-name",
+                "e2e-prod",
+                "--patch-operations",
+                patch_ops,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-prod"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/apigateway/test_v2_create_api.py
+++ b/tests/e2e/apigateway/test_v2_create_api.py
@@ -1,0 +1,34 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2CreateApi:
+    def test_v2_create_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        api_name = "e2e-v2-create-api"
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                api_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "apiId" in body
+        expected_name = api_name
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/e2e/apigateway/test_v2_create_integration.py
+++ b/tests/e2e/apigateway/test_v2_create_integration.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2CreateIntegration:
+    def test_v2_create_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-create-int",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-create-integration",
+                "--api-id",
+                api_id,
+                "--integration-type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "integrationId" in body
+        expected_type = "AWS_PROXY"
+        actual_type = body["integrationType"]
+        assert actual_type == expected_type

--- a/tests/e2e/apigateway/test_v2_create_route.py
+++ b/tests/e2e/apigateway/test_v2_create_route.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2CreateRoute:
+    def test_v2_create_route(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-create-route",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-create-route",
+                "--api-id",
+                api_id,
+                "--route-key",
+                "GET /items",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "routeId" in body
+        expected_route = "GET /items"
+        actual_route = body["routeKey"]
+        assert actual_route == expected_route

--- a/tests/e2e/apigateway/test_v2_create_stage.py
+++ b/tests/e2e/apigateway/test_v2_create_stage.py
@@ -1,0 +1,45 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2CreateStage:
+    def test_v2_create_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-create-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-create-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "e2e-dev",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-dev"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/apigateway/test_v2_delete_api.py
+++ b/tests/e2e/apigateway/test_v2_delete_api.py
@@ -1,0 +1,37 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2DeleteApi:
+    def test_v2_delete_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-delete-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-delete-api",
+                "--api-id",
+                api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_v2_delete_integration.py
+++ b/tests/e2e/apigateway/test_v2_delete_integration.py
@@ -1,0 +1,52 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2DeleteIntegration:
+    def test_v2_delete_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-del-int",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        integration = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-integration",
+                "--api-id",
+                api_id,
+                "--integration-type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        integration_id = integration["integrationId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-delete-integration",
+                "--api-id",
+                api_id,
+                "--integration-id",
+                integration_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_v2_delete_route.py
+++ b/tests/e2e/apigateway/test_v2_delete_route.py
@@ -1,0 +1,52 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2DeleteRoute:
+    def test_v2_delete_route(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-del-route",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        route = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-route",
+                "--api-id",
+                api_id,
+                "--route-key",
+                "DELETE /temp",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        route_id = route["routeId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-delete-route",
+                "--api-id",
+                api_id,
+                "--route-id",
+                route_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_v2_delete_stage.py
+++ b/tests/e2e/apigateway/test_v2_delete_stage.py
@@ -1,0 +1,51 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2DeleteStage:
+    def test_v2_delete_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-delete-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "to-delete",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-delete-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "to-delete",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/apigateway/test_v2_get_api.py
+++ b/tests/e2e/apigateway/test_v2_get_api.py
@@ -1,0 +1,43 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2GetApi:
+    def test_v2_get_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-get-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-get-api",
+                "--api-id",
+                api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_name = "e2e-v2-get-api"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/e2e/apigateway/test_v2_get_integration.py
+++ b/tests/e2e/apigateway/test_v2_get_integration.py
@@ -1,0 +1,58 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2GetIntegration:
+    def test_v2_get_integration(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-get-int",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        integration = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-integration",
+                "--api-id",
+                api_id,
+                "--integration-type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        integration_id = integration["integrationId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-get-integration",
+                "--api-id",
+                api_id,
+                "--integration-id",
+                integration_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_id = integration_id
+        actual_id = body["integrationId"]
+        assert actual_id == expected_id

--- a/tests/e2e/apigateway/test_v2_get_route.py
+++ b/tests/e2e/apigateway/test_v2_get_route.py
@@ -1,0 +1,58 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2GetRoute:
+    def test_v2_get_route(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-get-route",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        route = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-route",
+                "--api-id",
+                api_id,
+                "--route-key",
+                "POST /data",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        route_id = route["routeId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-get-route",
+                "--api-id",
+                api_id,
+                "--route-id",
+                route_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_route = "POST /data"
+        actual_route = body["routeKey"]
+        assert actual_route == expected_route

--- a/tests/e2e/apigateway/test_v2_get_stage.py
+++ b/tests/e2e/apigateway/test_v2_get_stage.py
@@ -1,0 +1,57 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2GetStage:
+    def test_v2_get_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-get-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "e2e-staging",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-get-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "e2e-staging",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-staging"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/apigateway/test_v2_list_apis.py
+++ b/tests/e2e/apigateway/test_v2_list_apis.py
@@ -1,0 +1,38 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2ListApis:
+    def test_v2_list_apis(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-list-apis",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-list-apis",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "items" in body

--- a/tests/e2e/apigateway/test_v2_list_integrations.py
+++ b/tests/e2e/apigateway/test_v2_list_integrations.py
@@ -1,0 +1,54 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2ListIntegrations:
+    def test_v2_list_integrations(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-list-ints",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-integration",
+                "--api-id",
+                api_id,
+                "--integration-type",
+                "AWS_PROXY",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-list-integrations",
+                "--api-id",
+                api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/e2e/apigateway/test_v2_list_routes.py
+++ b/tests/e2e/apigateway/test_v2_list_routes.py
@@ -1,0 +1,54 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2ListRoutes:
+    def test_v2_list_routes(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-list-routes",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-route",
+                "--api-id",
+                api_id,
+                "--route-key",
+                "GET /orders",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-list-routes",
+                "--api-id",
+                api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/e2e/apigateway/test_v2_list_stages.py
+++ b/tests/e2e/apigateway/test_v2_list_stages.py
@@ -1,0 +1,53 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2ListStages:
+    def test_v2_list_stages(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-list-stages",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-list-stages",
+                "--api-id",
+                api_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        assert "items" in body

--- a/tests/e2e/apigateway/test_v2_update_api.py
+++ b/tests/e2e/apigateway/test_v2_update_api.py
@@ -1,0 +1,45 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2UpdateApi:
+    def test_v2_update_api(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-update-api",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-update-api",
+                "--api-id",
+                api_id,
+                "--name",
+                "e2e-v2-updated",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_name = "e2e-v2-updated"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/e2e/apigateway/test_v2_update_stage.py
+++ b/tests/e2e/apigateway/test_v2_update_stage.py
@@ -1,0 +1,57 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestV2UpdateStage:
+    def test_v2_update_stage(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        created = lws_invoke(
+            [
+                "apigateway",
+                "v2-create-api",
+                "--name",
+                "e2e-v2-update-stage",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        api_id = created["apiId"]
+        lws_invoke(
+            [
+                "apigateway",
+                "v2-create-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "e2e-prod",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "apigateway",
+                "v2-update-stage",
+                "--api-id",
+                api_id,
+                "--stage-name",
+                "e2e-prod",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = json.loads(result.output)
+        expected_stage_name = "e2e-prod"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/e2e/cognito_idp/test_admin_create_user.py
+++ b/tests/e2e/cognito_idp/test_admin_create_user.py
@@ -1,0 +1,37 @@
+"""E2E test for Cognito admin-create-user CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestAdminCreateUser:
+    def test_admin_create_user(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-admin-create-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "admin-create-user",
+                "--user-pool-id",
+                user_pool_id,
+                "--username",
+                "e2e-admin-user",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_admin_delete_user.py
+++ b/tests/e2e/cognito_idp/test_admin_delete_user.py
@@ -1,0 +1,49 @@
+"""E2E test for Cognito admin-delete-user CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestAdminDeleteUser:
+    def test_admin_delete_user(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-admin-del-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+        lws_invoke(
+            [
+                "cognito-idp",
+                "admin-create-user",
+                "--user-pool-id",
+                user_pool_id,
+                "--username",
+                "e2e-admin-del-user",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "admin-delete-user",
+                "--user-pool-id",
+                user_pool_id,
+                "--username",
+                "e2e-admin-del-user",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_admin_get_user.py
+++ b/tests/e2e/cognito_idp/test_admin_get_user.py
@@ -1,0 +1,65 @@
+"""E2E test for Cognito admin-get-user CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestAdminGetUser:
+    def test_admin_get_user(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-admin-get-pool"
+        username = "e2e-admin-get-user"
+        password = "P@ssw0rd!123"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+        lws_invoke(
+            [
+                "cognito-idp",
+                "sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "confirm-sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "admin-get-user",
+                "--user-pool-id",
+                user_pool_id,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_change_password.py
+++ b/tests/e2e/cognito_idp/test_change_password.py
@@ -1,0 +1,102 @@
+"""E2E test for Cognito change-password CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestChangePassword:
+    def test_change_password_via_access_token(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        pool_name = "e2e-change-pw-pool"
+        username = "e2e-change-pw-user"
+        old_password = "P@ssw0rd!123"
+        new_password = "N3wP@ssw0rd!"
+        lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool",
+                "--pool-name",
+                pool_name,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                old_password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "confirm-sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        auth_result = lws_invoke(
+            [
+                "cognito-idp",
+                "initiate-auth",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                old_password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        access_token = auth_result["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "change-password",
+                "--access-token",
+                access_token,
+                "--previous-password",
+                old_password,
+                "--proposed-password",
+                new_password,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        new_auth = assert_invoke(
+            [
+                "cognito-idp",
+                "initiate-auth",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                new_password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        assert "AuthenticationResult" in new_auth

--- a/tests/e2e/cognito_idp/test_confirm_forgot_password.py
+++ b/tests/e2e/cognito_idp/test_confirm_forgot_password.py
@@ -1,0 +1,78 @@
+"""E2E test for Cognito confirm-forgot-password CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestConfirmForgotPassword:
+    def test_confirm_forgot_password_with_bad_code(self, e2e_port, lws_invoke, parse_output):
+        # Arrange
+        pool_name = "e2e-cfp-pool"
+        username = "e2e-cfp-user"
+        password = "P@ssw0rd!123"
+        new_password = "N3wP@ss!456"
+        lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool",
+                "--pool-name",
+                pool_name,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "confirm-sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "confirm-forgot-password",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--confirmation-code",
+                "000000",
+                "--password",
+                new_password,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        body = parse_output(result.output)
+        expected_error = "CodeMismatchException"
+        actual_error = body["__type"]
+        assert actual_error == expected_error

--- a/tests/e2e/cognito_idp/test_confirm_sign_up.py
+++ b/tests/e2e/cognito_idp/test_confirm_sign_up.py
@@ -9,7 +9,7 @@ class TestConfirmSignUp:
     def test_confirm_sign_up(self, e2e_port, lws_invoke):
         # Arrange
         pool_name = "e2e-confirm-pool"
-        username = "confirmuser"
+        username = "e2e-confirmuser"
         lws_invoke(
             ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
         )

--- a/tests/e2e/cognito_idp/test_create_user_pool_client.py
+++ b/tests/e2e/cognito_idp/test_create_user_pool_client.py
@@ -1,0 +1,37 @@
+"""E2E test for Cognito create-user-pool-client CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateUserPoolClient:
+    def test_create_user_pool_client(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-create-upc-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "create-user-pool-client",
+                "--user-pool-id",
+                user_pool_id,
+                "--client-name",
+                "e2e-test-client",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_delete_user_pool_client.py
+++ b/tests/e2e/cognito_idp/test_delete_user_pool_client.py
@@ -1,0 +1,50 @@
+"""E2E test for Cognito delete-user-pool-client CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteUserPoolClient:
+    def test_delete_user_pool_client(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-del-upc-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+        result_client = lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool-client",
+                "--user-pool-id",
+                user_pool_id,
+                "--client-name",
+                "e2e-del-client",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        client_id = result_client["UserPoolClient"]["ClientId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "delete-user-pool-client",
+                "--user-pool-id",
+                user_pool_id,
+                "--client-id",
+                client_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_describe_user_pool_client.py
+++ b/tests/e2e/cognito_idp/test_describe_user_pool_client.py
@@ -1,0 +1,50 @@
+"""E2E test for Cognito describe-user-pool-client CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDescribeUserPoolClient:
+    def test_describe_user_pool_client(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-desc-upc-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+        result_client = lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool-client",
+                "--user-pool-id",
+                user_pool_id,
+                "--client-name",
+                "e2e-desc-client",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        client_id = result_client["UserPoolClient"]["ClientId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "describe-user-pool-client",
+                "--user-pool-id",
+                user_pool_id,
+                "--client-id",
+                client_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_forgot_password.py
+++ b/tests/e2e/cognito_idp/test_forgot_password.py
@@ -1,0 +1,98 @@
+"""E2E test for Cognito forgot-password CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestForgotPassword:
+    def test_forgot_and_confirm_resets_password(self, e2e_port, lws_invoke, parse_output):
+        # Arrange
+        pool_name = "e2e-forgot-pw-pool"
+        username = "e2e-forgot-user"
+        old_password = "P@ssw0rd!123"
+        new_password = "N3wP@ssw0rd!"
+        lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool",
+                "--pool-name",
+                pool_name,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                old_password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "confirm-sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act - initiate forgot password
+        forgot_result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "forgot-password",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - forgot password succeeded
+        assert forgot_result.exit_code == 0, forgot_result.output
+        forgot_body = parse_output(forgot_result.output)
+        assert "CodeDeliveryDetails" in forgot_body
+
+        # Act - confirm forgot password with bad code
+        confirm_result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "confirm-forgot-password",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--confirmation-code",
+                "000000",
+                "--password",
+                new_password,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - confirm returns code mismatch error
+        assert confirm_result.exit_code == 0
+        confirm_body = parse_output(confirm_result.output)
+        expected_error = "CodeMismatchException"
+        actual_error = confirm_body["__type"]
+        assert actual_error == expected_error

--- a/tests/e2e/cognito_idp/test_global_sign_out.py
+++ b/tests/e2e/cognito_idp/test_global_sign_out.py
@@ -1,0 +1,82 @@
+"""E2E test for Cognito global-sign-out CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGlobalSignOut:
+    def test_global_sign_out_succeeds(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-signout-pool"
+        username = "e2e-signout-user"
+        password = "P@ssw0rd!123"
+        lws_invoke(
+            [
+                "cognito-idp",
+                "create-user-pool",
+                "--pool-name",
+                pool_name,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "cognito-idp",
+                "confirm-sign-up",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        auth_result = lws_invoke(
+            [
+                "cognito-idp",
+                "initiate-auth",
+                "--user-pool-name",
+                pool_name,
+                "--username",
+                username,
+                "--password",
+                password,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        access_token = auth_result["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "global-sign-out",
+                "--access-token",
+                access_token,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/cognito_idp/test_initiate_auth.py
+++ b/tests/e2e/cognito_idp/test_initiate_auth.py
@@ -11,7 +11,7 @@ class TestInitiateAuth:
     def test_initiate_auth(self, e2e_port, lws_invoke):
         # Arrange
         pool_name = "e2e-auth-pool"
-        username = "authuser"
+        username = "e2e-authuser"
         password = "P@ssw0rd!123"
         lws_invoke(
             ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]

--- a/tests/e2e/cognito_idp/test_list_user_pool_clients.py
+++ b/tests/e2e/cognito_idp/test_list_user_pool_clients.py
@@ -1,0 +1,35 @@
+"""E2E test for Cognito list-user-pool-clients CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListUserPoolClients:
+    def test_list_user_pool_clients(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-list-upc-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "list-user-pool-clients",
+                "--user-pool-id",
+                user_pool_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_list_users.py
+++ b/tests/e2e/cognito_idp/test_list_users.py
@@ -1,0 +1,35 @@
+"""E2E test for Cognito list-users CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListUsers:
+    def test_list_users(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-list-users-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "list-users",
+                "--user-pool-id",
+                user_pool_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/cognito_idp/test_update_user_pool.py
+++ b/tests/e2e/cognito_idp/test_update_user_pool.py
@@ -1,0 +1,35 @@
+"""E2E test for Cognito update-user-pool CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUpdateUserPool:
+    def test_update_user_pool(self, e2e_port, lws_invoke):
+        # Arrange
+        pool_name = "e2e-update-pool"
+        result_pool = lws_invoke(
+            ["cognito-idp", "create-user-pool", "--pool-name", pool_name, "--port", str(e2e_port)]
+        )
+        user_pool_id = result_pool["UserPool"]["Id"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "cognito-idp",
+                "update-user-pool",
+                "--user-pool-id",
+                user_pool_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        expected_exit_code = 0
+        actual_exit_code = result.exit_code
+        assert actual_exit_code == expected_exit_code, result.output

--- a/tests/e2e/dynamodb/test_batch_get_item.py
+++ b/tests/e2e/dynamodb/test_batch_get_item.py
@@ -1,0 +1,58 @@
+"""E2E test for DynamoDB batch-get-item CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestBatchGetItem:
+    def test_batch_get_item(self, e2e_port, lws_invoke):
+        # Arrange
+        table_name = "e2e-batch-get"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "dynamodb",
+                "put-item",
+                "--table-name",
+                table_name,
+                "--item",
+                json.dumps({"pk": {"S": "bg1"}, "data": {"S": "hello"}}),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        request_items = json.dumps({table_name: {"Keys": [{"pk": {"S": "bg1"}}]}})
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "batch-get-item",
+                "--request-items",
+                request_items,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/dynamodb/test_batch_write_item.py
+++ b/tests/e2e/dynamodb/test_batch_write_item.py
@@ -1,0 +1,53 @@
+"""E2E test for DynamoDB batch-write-item CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestBatchWriteItem:
+    def test_batch_write_item(self, e2e_port, lws_invoke):
+        # Arrange
+        table_name = "e2e-batch-write"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        request_items = json.dumps(
+            {
+                table_name: [
+                    {"PutRequest": {"Item": {"pk": {"S": "bw1"}, "data": {"S": "val1"}}}},
+                    {"PutRequest": {"Item": {"pk": {"S": "bw2"}, "data": {"S": "val2"}}}},
+                ]
+            }
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "batch-write-item",
+                "--request-items",
+                request_items,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/dynamodb/test_transact_get_items.py
+++ b/tests/e2e/dynamodb/test_transact_get_items.py
@@ -1,0 +1,67 @@
+"""E2E test for DynamoDB transact-get-items CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTransactGetItems:
+    def test_transact_get_items(self, e2e_port, lws_invoke):
+        # Arrange
+        table_name = "e2e-transact-get"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "dynamodb",
+                "put-item",
+                "--table-name",
+                table_name,
+                "--item",
+                json.dumps({"pk": {"S": "tg1"}, "data": {"S": "value"}}),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        transact_items = json.dumps(
+            [
+                {
+                    "Get": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "tg1"}},
+                    }
+                }
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "transact-get-items",
+                "--transact-items",
+                transact_items,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/dynamodb/test_transact_write_items.py
+++ b/tests/e2e/dynamodb/test_transact_write_items.py
@@ -1,0 +1,165 @@
+"""E2E test for DynamoDB transact-write-items CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTransactWriteItems:
+    def test_condition_check_pass_allows_writes(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        table_name = "e2e-transact-cc-pass"
+        expected_data = "written"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "dynamodb",
+                "put-item",
+                "--table-name",
+                table_name,
+                "--item",
+                json.dumps({"pk": {"S": "guard"}, "status": {"S": "ok"}}),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        transact_items = json.dumps(
+            [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "guard"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {
+                            "pk": {"S": "new-item"},
+                            "data": {"S": expected_data},
+                        },
+                    }
+                },
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "transact-write-items",
+                "--transact-items",
+                transact_items,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        verify = assert_invoke(
+            [
+                "dynamodb",
+                "get-item",
+                "--table-name",
+                table_name,
+                "--key",
+                '{"pk": {"S": "new-item"}}',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        actual_data = verify["Item"]["data"]["S"]
+        assert actual_data == expected_data
+
+    def test_condition_check_fail_blocks_writes(self, e2e_port, lws_invoke, parse_output):
+        # Arrange
+        table_name = "e2e-transact-cc-fail"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        transact_items = json.dumps(
+            [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "nonexistent"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {
+                            "pk": {"S": "blocked"},
+                            "data": {"S": "nope"},
+                        },
+                    }
+                },
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "transact-write-items",
+                "--transact-items",
+                transact_items,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0
+        body = parse_output(result.output)
+        expected_error = "com.amazonaws.dynamodb.v20120810#TransactionCanceledException"
+        actual_error = body["__type"]
+        assert actual_error == expected_error
+        get_result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "get-item",
+                "--table-name",
+                table_name,
+                "--key",
+                '{"pk": {"S": "blocked"}}',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+        get_body = parse_output(get_result.output)
+        assert "Item" not in get_body

--- a/tests/e2e/dynamodb/test_update_item.py
+++ b/tests/e2e/dynamodb/test_update_item.py
@@ -1,0 +1,80 @@
+"""E2E test for DynamoDB update-item CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUpdateItem:
+    def test_update_item(self, e2e_port, lws_invoke, assert_invoke):
+        # Arrange
+        table_name = "e2e-update-item"
+        expected_data = "updated"
+        lws_invoke(
+            [
+                "dynamodb",
+                "create-table",
+                "--table-name",
+                table_name,
+                "--key-schema",
+                '[{"AttributeName":"pk","KeyType":"HASH"}]',
+                "--attribute-definitions",
+                '[{"AttributeName":"pk","AttributeType":"S"}]',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "dynamodb",
+                "put-item",
+                "--table-name",
+                table_name,
+                "--item",
+                json.dumps({"pk": {"S": "k1"}, "data": {"S": "original"}}),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "dynamodb",
+                "update-item",
+                "--table-name",
+                table_name,
+                "--key",
+                '{"pk": {"S": "k1"}}',
+                "--update-expression",
+                "SET #d = :val",
+                "--expression-attribute-values",
+                json.dumps({":val": {"S": expected_data}}),
+                "--expression-attribute-names",
+                json.dumps({"#d": "data"}),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        verify = assert_invoke(
+            [
+                "dynamodb",
+                "get-item",
+                "--table-name",
+                table_name,
+                "--key",
+                '{"pk": {"S": "k1"}}',
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        actual_data = verify["Item"]["data"]["S"]
+        assert actual_data == expected_data

--- a/tests/e2e/events/test_describe_event_bus.py
+++ b/tests/e2e/events/test_describe_event_bus.py
@@ -1,0 +1,27 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDescribeEventBus:
+    def test_describe_event_bus(self, e2e_port):
+        # Arrange
+        target_eb = "default"
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "describe-event-bus",
+                "--name",
+                target_eb,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_describe_rule.py
+++ b/tests/e2e/events/test_describe_rule.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDescribeRule:
+    def test_describe_rule(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-desc-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "describe-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_disable_rule.py
+++ b/tests/e2e/events/test_disable_rule.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDisableRule:
+    def test_disable_rule(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-disable-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "disable-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_enable_rule.py
+++ b/tests/e2e/events/test_enable_rule.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestEnableRule:
+    def test_enable_rule(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-enable-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "enable-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_list_tags_for_resource.py
+++ b/tests/e2e/events/test_list_tags_for_resource.py
@@ -1,0 +1,29 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListTagsForResource:
+    def test_list_tags_for_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        bus_name = "e2e-list-tags-bus"
+        lws_invoke(["events", "create-event-bus", "--name", bus_name, "--port", str(e2e_port)])
+        resource_arn = "arn:aws:events:us-east-1:000000000000:event-bus/e2e-list-tags-bus"
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "list-tags-for-resource",
+                "--resource-arn",
+                resource_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_list_targets_by_rule.py
+++ b/tests/e2e/events/test_list_targets_by_rule.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListTargetsByRule:
+    def test_list_targets_by_rule(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-list-targets-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "list-targets-by-rule",
+                "--rule",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_put_targets.py
+++ b/tests/e2e/events/test_put_targets.py
@@ -1,0 +1,51 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestPutTargets:
+    def test_put_targets(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-put-targets-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        targets = json.dumps(
+            [{"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn"}]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "put-targets",
+                "--rule",
+                rule_name,
+                "--targets",
+                targets,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_remove_targets.py
+++ b/tests/e2e/events/test_remove_targets.py
@@ -1,0 +1,66 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestRemoveTargets:
+    def test_remove_targets(self, e2e_port, lws_invoke):
+        # Arrange
+        rule_name = "e2e-rm-targets-rule"
+        pattern = json.dumps({"source": ["e2e.test"]})
+        lws_invoke(
+            [
+                "events",
+                "put-rule",
+                "--name",
+                rule_name,
+                "--event-bus-name",
+                "default",
+                "--event-pattern",
+                pattern,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        targets = json.dumps(
+            [{"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn"}]
+        )
+        lws_invoke(
+            [
+                "events",
+                "put-targets",
+                "--rule",
+                rule_name,
+                "--targets",
+                targets,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        ids = json.dumps(["t1"])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "remove-targets",
+                "--rule",
+                rule_name,
+                "--ids",
+                ids,
+                "--event-bus-name",
+                "default",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_tag_resource.py
+++ b/tests/e2e/events/test_tag_resource.py
@@ -1,0 +1,34 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTagResource:
+    def test_tag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        bus_name = "e2e-tag-bus"
+        lws_invoke(["events", "create-event-bus", "--name", bus_name, "--port", str(e2e_port)])
+        resource_arn = "arn:aws:events:us-east-1:000000000000:event-bus/e2e-tag-bus"
+        tags = json.dumps([{"Key": "env", "Value": "test"}])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "tag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tags",
+                tags,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/events/test_untag_resource.py
+++ b/tests/e2e/events/test_untag_resource.py
@@ -1,0 +1,47 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUntagResource:
+    def test_untag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        bus_name = "e2e-untag-bus"
+        lws_invoke(["events", "create-event-bus", "--name", bus_name, "--port", str(e2e_port)])
+        resource_arn = "arn:aws:events:us-east-1:000000000000:event-bus/e2e-untag-bus"
+        tags = json.dumps([{"Key": "env", "Value": "test"}])
+        lws_invoke(
+            [
+                "events",
+                "tag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tags",
+                tags,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        tag_keys = json.dumps(["env"])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "events",
+                "untag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tag-keys",
+                tag_keys,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_create_event_source_mapping.py
+++ b/tests/e2e/lambda_/test_create_event_source_mapping.py
@@ -1,0 +1,59 @@
+"""E2E test for Lambda create-event-source-mapping CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateEventSourceMapping:
+    def test_create_list_delete_event_source_mapping(self, e2e_port, parse_output, assert_invoke):
+        # Arrange
+        expected_function_name = "e2e-esm-function"
+        expected_arn = "arn:aws:sqs:us-east-1:000000000000:e2e-esm-queue"
+        expected_batch_size = 5
+
+        # Act - create
+        create_result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "create-event-source-mapping",
+                "--function-name",
+                expected_function_name,
+                "--event-source-arn",
+                expected_arn,
+                "--batch-size",
+                str(expected_batch_size),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - create succeeded
+        assert create_result.exit_code == 0, create_result.output
+        created = parse_output(create_result.output)
+        esm_uuid = created["UUID"]
+        assert esm_uuid
+
+        # Assert - list contains the mapping
+        list_body = assert_invoke(["lambda", "list-event-source-mappings", "--port", str(e2e_port)])
+        actual_uuids = [m["UUID"] for m in list_body["EventSourceMappings"]]
+        assert esm_uuid in actual_uuids
+
+        # Act - delete
+        delete_result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "delete-event-source-mapping",
+                "--uuid",
+                esm_uuid,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - delete succeeded
+        assert delete_result.exit_code == 0, delete_result.output

--- a/tests/e2e/lambda_/test_create_function.py
+++ b/tests/e2e/lambda_/test_create_function.py
@@ -1,0 +1,78 @@
+"""E2E test for Lambda create-function CLI command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+_DOCKER_AVAILABLE = True
+try:
+    subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    _DOCKER_AVAILABLE = False
+
+_LAMBDA_IMAGE_AVAILABLE = False
+if _DOCKER_AVAILABLE:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "public.ecr.aws/lambda/python:3.12"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        _LAMBDA_IMAGE_AVAILABLE = bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+_HANDLER_CODE = """\
+def handler(event, context):
+    return {"statusCode": 200}
+"""
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker daemon not reachable")
+@pytest.mark.skipif(
+    not _LAMBDA_IMAGE_AVAILABLE,
+    reason="public.ecr.aws/lambda/python:3.12 image not available locally",
+)
+class TestCreateFunction:
+    def test_create_function(self, e2e_port):
+        # Arrange
+        function_name = "e2e-create-fn"
+
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as handler_dir:
+            handler_file = Path(handler_dir) / "handler.py"
+            handler_file.write_text(_HANDLER_CODE)
+
+            # Act
+            result = runner.invoke(
+                app,
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ],
+            )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_delete_event_source_mapping.py
+++ b/tests/e2e/lambda_/test_delete_event_source_mapping.py
@@ -1,0 +1,43 @@
+"""E2E test for Lambda delete-event-source-mapping CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteEventSourceMapping:
+    def test_create_then_delete_event_source_mapping(self, e2e_port, lws_invoke, parse_output):
+        # Arrange
+        expected_function_name = "e2e-del-esm-fn"
+        expected_arn = "arn:aws:sqs:us-east-1:000000000000:e2e-del-esm-queue"
+        create_body = lws_invoke(
+            [
+                "lambda",
+                "create-event-source-mapping",
+                "--function-name",
+                expected_function_name,
+                "--event-source-arn",
+                expected_arn,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        esm_uuid = create_body["UUID"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "delete-event-source-mapping",
+                "--uuid",
+                esm_uuid,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_delete_function.py
+++ b/tests/e2e/lambda_/test_delete_function.py
@@ -1,0 +1,87 @@
+"""E2E test for Lambda delete-function CLI command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+_DOCKER_AVAILABLE = True
+try:
+    subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    _DOCKER_AVAILABLE = False
+
+_LAMBDA_IMAGE_AVAILABLE = False
+if _DOCKER_AVAILABLE:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "public.ecr.aws/lambda/python:3.12"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        _LAMBDA_IMAGE_AVAILABLE = bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+_HANDLER_CODE = """\
+def handler(event, context):
+    return {"statusCode": 200}
+"""
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker daemon not reachable")
+@pytest.mark.skipif(
+    not _LAMBDA_IMAGE_AVAILABLE,
+    reason="public.ecr.aws/lambda/python:3.12 image not available locally",
+)
+class TestDeleteFunction:
+    def test_delete_function(self, e2e_port, lws_invoke):
+        # Arrange
+        function_name = "e2e-del-fn"
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as handler_dir:
+            handler_file = Path(handler_dir) / "handler.py"
+            handler_file.write_text(_HANDLER_CODE)
+            lws_invoke(
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ]
+            )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "delete-function",
+                "--function-name",
+                function_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_get_function.py
+++ b/tests/e2e/lambda_/test_get_function.py
@@ -1,0 +1,87 @@
+"""E2E test for Lambda get-function CLI command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+_DOCKER_AVAILABLE = True
+try:
+    subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    _DOCKER_AVAILABLE = False
+
+_LAMBDA_IMAGE_AVAILABLE = False
+if _DOCKER_AVAILABLE:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "public.ecr.aws/lambda/python:3.12"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        _LAMBDA_IMAGE_AVAILABLE = bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+_HANDLER_CODE = """\
+def handler(event, context):
+    return {"statusCode": 200}
+"""
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker daemon not reachable")
+@pytest.mark.skipif(
+    not _LAMBDA_IMAGE_AVAILABLE,
+    reason="public.ecr.aws/lambda/python:3.12 image not available locally",
+)
+class TestGetFunction:
+    def test_get_function(self, e2e_port, lws_invoke):
+        # Arrange
+        function_name = "e2e-get-fn"
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as handler_dir:
+            handler_file = Path(handler_dir) / "handler.py"
+            handler_file.write_text(_HANDLER_CODE)
+            lws_invoke(
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ]
+            )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "get-function",
+                "--function-name",
+                function_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_lambda_s3_integration.py
+++ b/tests/e2e/lambda_/test_lambda_s3_integration.py
@@ -1,12 +1,12 @@
-"""E2E test for Lambda → S3 path-style addressing integration."""
+"""E2E test for Lambda -> S3 path-style addressing integration."""
 
 from __future__ import annotations
 
+import json
 import subprocess
 import tempfile
 from pathlib import Path
 
-import httpx
 import pytest
 from typer.testing import CliRunner
 
@@ -54,13 +54,12 @@ def handler(event, context):
     reason="public.ecr.aws/lambda/python:3.12 image not available locally",
 )
 class TestLambdaS3Integration:
-    def test_lambda_writes_to_s3(self, e2e_port, lws_invoke, assert_invoke):
+    def test_lambda_writes_to_s3(self, e2e_port, lws_invoke, assert_invoke, parse_output):
         # Arrange
         bucket_name = "e2e-lambda-s3-bucket"
         object_key = "e2e-lambda-output.txt"
         expected_body = "hello from lambda"
         function_name = "e2e-s3-writer"
-        lambda_port = e2e_port + 9
 
         lws_invoke(["s3api", "create-bucket", "--bucket", bucket_name, "--port", str(e2e_port)])
 
@@ -68,30 +67,48 @@ class TestLambdaS3Integration:
             handler_file = Path(handler_dir) / "handler.py"
             handler_file.write_text(_HANDLER_CODE)
 
-            resp = httpx.post(
-                f"http://localhost:{lambda_port}/2015-03-31/functions",
-                json={
-                    "FunctionName": function_name,
-                    "Runtime": "python3.12",
-                    "Handler": "handler.handler",
-                    "Code": {"Filename": handler_dir},
-                    "Timeout": 30,
-                },
-                timeout=30.0,
+            create_result = runner.invoke(
+                app,
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ],
             )
-            assert resp.status_code == 201, f"CreateFunction failed: {resp.text}"
+            assert create_result.exit_code == 0, create_result.output
 
             # Act
-            event_payload = {"bucket": bucket_name, "key": object_key, "body": expected_body}
-            invoke_resp = httpx.post(
-                f"http://localhost:{lambda_port}/2015-03-31/functions/{function_name}/invocations",
-                json=event_payload,
-                timeout=60.0,
+            event_payload = json.dumps(
+                {"bucket": bucket_name, "key": object_key, "body": expected_body}
+            )
+            invoke_result = runner.invoke(
+                app,
+                [
+                    "lambda",
+                    "invoke",
+                    "--function-name",
+                    function_name,
+                    "--event",
+                    event_payload,
+                    "--port",
+                    str(e2e_port),
+                ],
             )
 
         # Assert
-        assert invoke_resp.status_code == 200, invoke_resp.text
-        actual_result = invoke_resp.json()
+        assert invoke_result.exit_code == 0, invoke_result.output
+        actual_result = parse_output(invoke_result.output)
         assert actual_result.get("statusCode") == 200
 
         outfile = Path(tempfile.mktemp(suffix=".txt"))

--- a/tests/e2e/lambda_/test_list_event_source_mappings.py
+++ b/tests/e2e/lambda_/test_list_event_source_mappings.py
@@ -1,0 +1,21 @@
+"""E2E test for Lambda list-event-source-mappings CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListEventSourceMappings:
+    def test_list_event_source_mappings(self, e2e_port):
+        # Arrange — no setup needed
+
+        # Act
+        result = runner.invoke(
+            app,
+            ["lambda", "list-event-source-mappings", "--port", str(e2e_port)],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_list_functions.py
+++ b/tests/e2e/lambda_/test_list_functions.py
@@ -1,0 +1,21 @@
+"""E2E test for Lambda list-functions CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListFunctions:
+    def test_list_functions(self, e2e_port):
+        # Arrange — no setup needed
+
+        # Act
+        result = runner.invoke(
+            app,
+            ["lambda", "list-functions", "--port", str(e2e_port)],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_update_function_code.py
+++ b/tests/e2e/lambda_/test_update_function_code.py
@@ -1,0 +1,92 @@
+"""E2E test for Lambda update-function-code CLI command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+_DOCKER_AVAILABLE = True
+try:
+    subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    _DOCKER_AVAILABLE = False
+
+_LAMBDA_IMAGE_AVAILABLE = False
+if _DOCKER_AVAILABLE:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "public.ecr.aws/lambda/python:3.12"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        _LAMBDA_IMAGE_AVAILABLE = bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+_HANDLER_CODE = """\
+def handler(event, context):
+    return {"statusCode": 200}
+"""
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker daemon not reachable")
+@pytest.mark.skipif(
+    not _LAMBDA_IMAGE_AVAILABLE,
+    reason="public.ecr.aws/lambda/python:3.12 image not available locally",
+)
+class TestUpdateFunctionCode:
+    def test_update_function_code(self, e2e_port, lws_invoke):
+        # Arrange
+        function_name = "e2e-upd-code-fn"
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as handler_dir:
+            handler_file = Path(handler_dir) / "handler.py"
+            handler_file.write_text(_HANDLER_CODE)
+            lws_invoke(
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ]
+            )
+
+        # Act
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as new_handler_dir:
+            new_handler_file = Path(new_handler_dir) / "handler.py"
+            new_handler_file.write_text(_HANDLER_CODE)
+            result = runner.invoke(
+                app,
+                [
+                    "lambda",
+                    "update-function-code",
+                    "--function-name",
+                    function_name,
+                    "--code",
+                    json.dumps({"Filename": new_handler_dir}),
+                    "--port",
+                    str(e2e_port),
+                ],
+            )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/lambda_/test_update_function_configuration.py
+++ b/tests/e2e/lambda_/test_update_function_configuration.py
@@ -1,0 +1,89 @@
+"""E2E test for Lambda update-function-configuration CLI command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+_DOCKER_AVAILABLE = True
+try:
+    subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=True)
+except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    _DOCKER_AVAILABLE = False
+
+_LAMBDA_IMAGE_AVAILABLE = False
+if _DOCKER_AVAILABLE:
+    try:
+        result = subprocess.run(
+            ["docker", "images", "-q", "public.ecr.aws/lambda/python:3.12"],
+            capture_output=True,
+            timeout=5,
+            text=True,
+        )
+        _LAMBDA_IMAGE_AVAILABLE = bool(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+_HANDLER_CODE = """\
+def handler(event, context):
+    return {"statusCode": 200}
+"""
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason="Docker daemon not reachable")
+@pytest.mark.skipif(
+    not _LAMBDA_IMAGE_AVAILABLE,
+    reason="public.ecr.aws/lambda/python:3.12 image not available locally",
+)
+class TestUpdateFunctionConfiguration:
+    def test_update_function_configuration(self, e2e_port, lws_invoke):
+        # Arrange
+        function_name = "e2e-upd-cfg-fn"
+        with tempfile.TemporaryDirectory(dir=str(Path.home())) as handler_dir:
+            handler_file = Path(handler_dir) / "handler.py"
+            handler_file.write_text(_HANDLER_CODE)
+            lws_invoke(
+                [
+                    "lambda",
+                    "create-function",
+                    "--function-name",
+                    function_name,
+                    "--runtime",
+                    "python3.12",
+                    "--handler",
+                    "handler.handler",
+                    "--code",
+                    json.dumps({"Filename": handler_dir}),
+                    "--timeout",
+                    "30",
+                    "--port",
+                    str(e2e_port),
+                ]
+            )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "lambda",
+                "update-function-configuration",
+                "--function-name",
+                function_name,
+                "--timeout",
+                "60",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/s3api/test_abort_multipart_upload.py
+++ b/tests/e2e/s3api/test_abort_multipart_upload.py
@@ -1,0 +1,48 @@
+"""E2E test for S3 abort-multipart-upload CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestAbortMultipartUpload:
+    def test_abort_multipart_upload(self, e2e_port, lws_invoke):
+        # Arrange
+        bucket = "e2e-abort-mp"
+        key = "e2e-abort.bin"
+        lws_invoke(["s3api", "create-bucket", "--bucket", bucket, "--port", str(e2e_port)])
+        create_body = lws_invoke(
+            [
+                "s3api",
+                "create-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        upload_id = create_body["InitiateMultipartUploadResult"]["UploadId"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "abort-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/s3api/test_complete_multipart_upload.py
+++ b/tests/e2e/s3api/test_complete_multipart_upload.py
@@ -1,0 +1,75 @@
+"""E2E test for S3 complete-multipart-upload CLI command."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCompleteMultipartUpload:
+    def test_complete_multipart_upload(self, e2e_port, tmp_path, lws_invoke, parse_output):
+        # Arrange
+        bucket = "e2e-complete-mp"
+        key = "e2e-complete.bin"
+        part_content = b"complete-data"
+        lws_invoke(["s3api", "create-bucket", "--bucket", bucket, "--port", str(e2e_port)])
+        create_body = lws_invoke(
+            [
+                "s3api",
+                "create-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        upload_id = create_body["InitiateMultipartUploadResult"]["UploadId"]
+        part_file = tmp_path / "part.bin"
+        part_file.write_bytes(part_content)
+        upload_body = lws_invoke(
+            [
+                "s3api",
+                "upload-part",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--part-number",
+                "1",
+                "--body",
+                str(part_file),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        etag = upload_body["ETag"]
+        parts_json = json.dumps({"Parts": [{"PartNumber": 1, "ETag": etag}]})
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "complete-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--multipart-upload",
+                parts_json,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/s3api/test_create_multipart_upload.py
+++ b/tests/e2e/s3api/test_create_multipart_upload.py
@@ -1,0 +1,142 @@
+"""E2E test for S3 multipart upload workflow via CLI commands."""
+
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestCreateMultipartUpload:
+    def test_full_multipart_workflow(self, e2e_port, tmp_path, lws_invoke, parse_output):
+        # Arrange
+        bucket = "e2e-multipart"
+        key = "e2e-multi.bin"
+        part1_content = b"first-part-"
+        part2_content = b"second-part"
+        expected_body = part1_content + part2_content
+        lws_invoke(["s3api", "create-bucket", "--bucket", bucket, "--port", str(e2e_port)])
+
+        # Act - create multipart upload
+        create_result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "create-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - initiate succeeded
+        assert create_result.exit_code == 0, create_result.output
+        create_body = parse_output(create_result.output)
+        upload_id = create_body["InitiateMultipartUploadResult"]["UploadId"]
+
+        # Act - upload part 1
+        part1_file = tmp_path / "part1.bin"
+        part1_file.write_bytes(part1_content)
+        upload1_result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "upload-part",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--part-number",
+                "1",
+                "--body",
+                str(part1_file),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - part 1 uploaded
+        assert upload1_result.exit_code == 0, upload1_result.output
+        etag1 = parse_output(upload1_result.output)["ETag"]
+
+        # Act - upload part 2
+        part2_file = tmp_path / "part2.bin"
+        part2_file.write_bytes(part2_content)
+        upload2_result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "upload-part",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--part-number",
+                "2",
+                "--body",
+                str(part2_file),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - part 2 uploaded
+        assert upload2_result.exit_code == 0, upload2_result.output
+        etag2 = parse_output(upload2_result.output)["ETag"]
+
+        # Act - complete multipart upload
+        parts_json = json.dumps(
+            {
+                "Parts": [
+                    {"PartNumber": 1, "ETag": etag1},
+                    {"PartNumber": 2, "ETag": etag2},
+                ]
+            }
+        )
+        complete_result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "complete-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--multipart-upload",
+                parts_json,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert - complete succeeded, object readable
+        assert complete_result.exit_code == 0, complete_result.output
+        outfile = tmp_path / "verify.bin"
+        verify_result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "get-object",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                str(outfile),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+        assert verify_result.exit_code == 0, verify_result.output
+        actual_body = outfile.read_bytes()
+        assert actual_body == expected_body

--- a/tests/e2e/s3api/test_upload_part.py
+++ b/tests/e2e/s3api/test_upload_part.py
@@ -1,0 +1,57 @@
+"""E2E test for S3 upload-part CLI command."""
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUploadPart:
+    def test_upload_part(self, e2e_port, tmp_path, lws_invoke, parse_output):
+        # Arrange
+        bucket = "e2e-upload-part"
+        key = "e2e-part.bin"
+        part_content = b"part-data"
+        lws_invoke(["s3api", "create-bucket", "--bucket", bucket, "--port", str(e2e_port)])
+        create_body = lws_invoke(
+            [
+                "s3api",
+                "create-multipart-upload",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        upload_id = create_body["InitiateMultipartUploadResult"]["UploadId"]
+        part_file = tmp_path / "part.bin"
+        part_file.write_bytes(part_content)
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "s3api",
+                "upload-part",
+                "--bucket",
+                bucket,
+                "--key",
+                key,
+                "--upload-id",
+                upload_id,
+                "--part-number",
+                "1",
+                "--body",
+                str(part_file),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        body = parse_output(result.output)
+        assert "ETag" in body

--- a/tests/e2e/secretsmanager/test_get_resource_policy.py
+++ b/tests/e2e/secretsmanager/test_get_resource_policy.py
@@ -1,0 +1,39 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetResourcePolicy:
+    def test_get_resource_policy(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-get-resource-policy"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "get-resource-policy",
+                "--secret-id",
+                secret_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/secretsmanager/test_list_secret_version_ids.py
+++ b/tests/e2e/secretsmanager/test_list_secret_version_ids.py
@@ -1,0 +1,39 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListSecretVersionIds:
+    def test_list_secret_version_ids(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-list-version-ids"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "list-secret-version-ids",
+                "--secret-id",
+                secret_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/secretsmanager/test_restore_secret.py
+++ b/tests/e2e/secretsmanager/test_restore_secret.py
@@ -1,0 +1,49 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestRestoreSecret:
+    def test_restore_secret(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-restore-secret"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "secretsmanager",
+                "delete-secret",
+                "--secret-id",
+                secret_name,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "restore-secret",
+                "--secret-id",
+                secret_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/secretsmanager/test_tag_resource.py
+++ b/tests/e2e/secretsmanager/test_tag_resource.py
@@ -1,0 +1,43 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTagResource:
+    def test_tag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-tag-resource"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "tag-resource",
+                "--secret-id",
+                secret_name,
+                "--tags",
+                json.dumps([{"Key": "env", "Value": "test"}]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/secretsmanager/test_untag_resource.py
+++ b/tests/e2e/secretsmanager/test_untag_resource.py
@@ -1,0 +1,55 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUntagResource:
+    def test_untag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-untag-resource"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "secretsmanager",
+                "tag-resource",
+                "--secret-id",
+                secret_name,
+                "--tags",
+                json.dumps([{"Key": "env", "Value": "test"}]),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "untag-resource",
+                "--secret-id",
+                secret_name,
+                "--tag-keys",
+                json.dumps(["env"]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/secretsmanager/test_update_secret.py
+++ b/tests/e2e/secretsmanager/test_update_secret.py
@@ -1,0 +1,41 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUpdateSecret:
+    def test_update_secret(self, e2e_port, lws_invoke):
+        # Arrange
+        secret_name = "e2e-update-secret"
+        lws_invoke(
+            [
+                "secretsmanager",
+                "create-secret",
+                "--name",
+                secret_name,
+                "--secret-string",
+                "old-val",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "secretsmanager",
+                "update-secret",
+                "--secret-id",
+                secret_name,
+                "--secret-string",
+                "new-val",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_confirm_subscription.py
+++ b/tests/e2e/sns/test_confirm_subscription.py
@@ -1,0 +1,36 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestConfirmSubscription:
+    def test_confirm_subscription(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-confirm-sub"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "confirm-subscription",
+                "--topic-arn",
+                topic_arn,
+                "--token",
+                "dummy-token",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_get_subscription_attributes.py
+++ b/tests/e2e/sns/test_get_subscription_attributes.py
@@ -1,0 +1,53 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetSubscriptionAttributes:
+    def test_get_subscription_attributes(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-get-sub-attrs"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+        sub_data = lws_invoke(
+            [
+                "sns",
+                "subscribe",
+                "--topic-arn",
+                topic_arn,
+                "--protocol",
+                "sqs",
+                "--notification-endpoint",
+                "arn:aws:sqs:us-east-1:000000000000:e2e-get-sub-attrs-q",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        subscription_arn = (
+            sub_data.get("SubscribeResponse", {})
+            .get("SubscribeResult", {})
+            .get("SubscriptionArn", "")
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "get-subscription-attributes",
+                "--subscription-arn",
+                subscription_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_get_topic_attributes.py
+++ b/tests/e2e/sns/test_get_topic_attributes.py
@@ -1,0 +1,34 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetTopicAttributes:
+    def test_get_topic_attributes(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-get-topic-attrs"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "get-topic-attributes",
+                "--topic-arn",
+                topic_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_list_subscriptions_by_topic.py
+++ b/tests/e2e/sns/test_list_subscriptions_by_topic.py
@@ -1,0 +1,34 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListSubscriptionsByTopic:
+    def test_list_subscriptions_by_topic(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-list-subs-topic"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "list-subscriptions-by-topic",
+                "--topic-arn",
+                topic_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_list_tags_for_resource.py
+++ b/tests/e2e/sns/test_list_tags_for_resource.py
@@ -1,0 +1,34 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListTagsForResource:
+    def test_list_tags_for_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-list-tags-res"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "list-tags-for-resource",
+                "--resource-arn",
+                topic_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_set_subscription_attributes.py
+++ b/tests/e2e/sns/test_set_subscription_attributes.py
@@ -1,0 +1,57 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestSetSubscriptionAttributes:
+    def test_set_subscription_attributes(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-set-sub-attrs"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+        sub_data = lws_invoke(
+            [
+                "sns",
+                "subscribe",
+                "--topic-arn",
+                topic_arn,
+                "--protocol",
+                "sqs",
+                "--notification-endpoint",
+                "arn:aws:sqs:us-east-1:000000000000:e2e-set-sub-attrs-q",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        subscription_arn = (
+            sub_data.get("SubscribeResponse", {})
+            .get("SubscribeResult", {})
+            .get("SubscriptionArn", "")
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "set-subscription-attributes",
+                "--subscription-arn",
+                subscription_arn,
+                "--attribute-name",
+                "RawMessageDelivery",
+                "--attribute-value",
+                "true",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_set_topic_attributes.py
+++ b/tests/e2e/sns/test_set_topic_attributes.py
@@ -1,0 +1,38 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestSetTopicAttributes:
+    def test_set_topic_attributes(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-set-topic-attrs"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "set-topic-attributes",
+                "--topic-arn",
+                topic_arn,
+                "--attribute-name",
+                "DisplayName",
+                "--attribute-value",
+                "E2E Test Topic",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_tag_resource.py
+++ b/tests/e2e/sns/test_tag_resource.py
@@ -1,0 +1,36 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTagResource:
+    def test_tag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-tag-res"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "tag-resource",
+                "--resource-arn",
+                topic_arn,
+                "--tags",
+                '[{"Key":"env","Value":"test"}]',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_unsubscribe.py
+++ b/tests/e2e/sns/test_unsubscribe.py
@@ -1,0 +1,53 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUnsubscribe:
+    def test_unsubscribe(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-unsub-topic"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+        sub_data = lws_invoke(
+            [
+                "sns",
+                "subscribe",
+                "--topic-arn",
+                topic_arn,
+                "--protocol",
+                "sqs",
+                "--notification-endpoint",
+                "arn:aws:sqs:us-east-1:000000000000:e2e-unsub-queue",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        subscription_arn = (
+            sub_data.get("SubscribeResponse", {})
+            .get("SubscribeResult", {})
+            .get("SubscriptionArn", "")
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "unsubscribe",
+                "--subscription-arn",
+                subscription_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sns/test_untag_resource.py
+++ b/tests/e2e/sns/test_untag_resource.py
@@ -1,0 +1,49 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUntagResource:
+    def test_untag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        topic_name = "e2e-untag-res"
+        data = lws_invoke(["sns", "create-topic", "--name", topic_name, "--port", str(e2e_port)])
+        default_arn = f"arn:aws:sns:us-east-1:000000000000:{topic_name}"
+        topic_arn = (
+            data.get("CreateTopicResponse", {})
+            .get("CreateTopicResult", {})
+            .get("TopicArn", default_arn)
+        )
+        runner.invoke(
+            app,
+            [
+                "sns",
+                "tag-resource",
+                "--resource-arn",
+                topic_arn,
+                "--tags",
+                '[{"Key":"env","Value":"test"}]',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sns",
+                "untag-resource",
+                "--resource-arn",
+                topic_arn,
+                "--tag-keys",
+                '["env"]',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_change_message_visibility.py
+++ b/tests/e2e/sqs/test_change_message_visibility.py
@@ -1,0 +1,53 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestChangeMessageVisibility:
+    def test_change_message_visibility(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-chg-vis"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+        lws_invoke(
+            [
+                "sqs",
+                "send-message",
+                "--queue-name",
+                queue_name,
+                "--message-body",
+                "vis-test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        recv_output = lws_invoke(
+            ["sqs", "receive-message", "--queue-name", queue_name, "--port", str(e2e_port)]
+        )
+        receipt_handle = (
+            recv_output.get("ReceiveMessageResponse", {})
+            .get("ReceiveMessageResult", {})
+            .get("Message", {})
+            .get("ReceiptHandle", "")
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "change-message-visibility",
+                "--queue-name",
+                queue_name,
+                "--receipt-handle",
+                receipt_handle,
+                "--visibility-timeout",
+                "60",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_change_message_visibility_batch.py
+++ b/tests/e2e/sqs/test_change_message_visibility_batch.py
@@ -1,0 +1,54 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestChangeMessageVisibilityBatch:
+    def test_change_message_visibility_batch(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-chg-vis-batch"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+        lws_invoke(
+            [
+                "sqs",
+                "send-message",
+                "--queue-name",
+                queue_name,
+                "--message-body",
+                "vis-batch-test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        recv_output = lws_invoke(
+            ["sqs", "receive-message", "--queue-name", queue_name, "--port", str(e2e_port)]
+        )
+        receipt_handle = (
+            recv_output.get("ReceiveMessageResponse", {})
+            .get("ReceiveMessageResult", {})
+            .get("Message", {})
+            .get("ReceiptHandle", "")
+        )
+        entries_json = (
+            '[{"Id":"1","ReceiptHandle":"' + receipt_handle + '","VisibilityTimeout":60}]'
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "change-message-visibility-batch",
+                "--queue-name",
+                queue_name,
+                "--entries",
+                entries_json,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_delete_message_batch.py
+++ b/tests/e2e/sqs/test_delete_message_batch.py
@@ -1,0 +1,52 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteMessageBatch:
+    def test_delete_message_batch(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-delmsg-batch"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+        lws_invoke(
+            [
+                "sqs",
+                "send-message",
+                "--queue-name",
+                queue_name,
+                "--message-body",
+                "batch-delete-me",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        recv_output = lws_invoke(
+            ["sqs", "receive-message", "--queue-name", queue_name, "--port", str(e2e_port)]
+        )
+        receipt_handle = (
+            recv_output.get("ReceiveMessageResponse", {})
+            .get("ReceiveMessageResult", {})
+            .get("Message", {})
+            .get("ReceiptHandle", "")
+        )
+        entries_json = '[{"Id":"1","ReceiptHandle":"' + receipt_handle + '"}]'
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "delete-message-batch",
+                "--queue-name",
+                queue_name,
+                "--entries",
+                entries_json,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_get_queue_url.py
+++ b/tests/e2e/sqs/test_get_queue_url.py
@@ -1,0 +1,28 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetQueueUrl:
+    def test_get_queue_url(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-get-queue-url"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "get-queue-url",
+                "--queue-name",
+                queue_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_list_dead_letter_source_queues.py
+++ b/tests/e2e/sqs/test_list_dead_letter_source_queues.py
@@ -1,0 +1,28 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListDeadLetterSourceQueues:
+    def test_list_dead_letter_source_queues(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-list-dlq-src"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "list-dead-letter-source-queues",
+                "--queue-name",
+                queue_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_list_queue_tags.py
+++ b/tests/e2e/sqs/test_list_queue_tags.py
@@ -1,0 +1,28 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListQueueTags:
+    def test_list_queue_tags(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-list-q-tags"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "list-queue-tags",
+                "--queue-name",
+                queue_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_send_message_batch.py
+++ b/tests/e2e/sqs/test_send_message_batch.py
@@ -1,0 +1,30 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestSendMessageBatch:
+    def test_send_message_batch(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-send-msg-batch"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "send-message-batch",
+                "--queue-name",
+                queue_name,
+                "--entries",
+                '[{"Id":"1","MessageBody":"msg1"}]',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_set_queue_attributes.py
+++ b/tests/e2e/sqs/test_set_queue_attributes.py
@@ -1,0 +1,30 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestSetQueueAttributes:
+    def test_set_queue_attributes(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-set-queue-attrs"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "set-queue-attributes",
+                "--queue-name",
+                queue_name,
+                "--attributes",
+                '{"VisibilityTimeout":"30"}',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_tag_queue.py
+++ b/tests/e2e/sqs/test_tag_queue.py
@@ -1,0 +1,30 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestTagQueue:
+    def test_tag_queue(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-tag-q"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "tag-queue",
+                "--queue-name",
+                queue_name,
+                "--tags",
+                '{"env":"test"}',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/sqs/test_untag_queue.py
+++ b/tests/e2e/sqs/test_untag_queue.py
@@ -1,0 +1,43 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestUntagQueue:
+    def test_untag_queue(self, e2e_port, lws_invoke):
+        # Arrange
+        queue_name = "e2e-untag-q"
+        lws_invoke(["sqs", "create-queue", "--queue-name", queue_name, "--port", str(e2e_port)])
+        runner.invoke(
+            app,
+            [
+                "sqs",
+                "tag-queue",
+                "--queue-name",
+                queue_name,
+                "--tags",
+                '{"env":"test"}',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "sqs",
+                "untag-queue",
+                "--queue-name",
+                queue_name,
+                "--tag-keys",
+                '["env"]',
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/ssm/test_add_tags_to_resource.py
+++ b/tests/e2e/ssm/test_add_tags_to_resource.py
@@ -1,0 +1,47 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestAddTagsToResource:
+    def test_add_tags_to_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        param_name = "/e2e/add-tags-test"
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name,
+                "--value",
+                "val1",
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "ssm",
+                "add-tags-to-resource",
+                "--resource-type",
+                "Parameter",
+                "--resource-id",
+                param_name,
+                "--tags",
+                json.dumps([{"Key": "env", "Value": "test"}]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/ssm/test_delete_parameters.py
+++ b/tests/e2e/ssm/test_delete_parameters.py
@@ -1,0 +1,43 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestDeleteParameters:
+    def test_delete_parameters(self, e2e_port, lws_invoke):
+        # Arrange
+        param_name = "/e2e/del-params-test"
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name,
+                "--value",
+                "val1",
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "ssm",
+                "delete-parameters",
+                "--names",
+                json.dumps([param_name]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/ssm/test_get_parameters.py
+++ b/tests/e2e/ssm/test_get_parameters.py
@@ -1,0 +1,60 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestGetParameters:
+    def test_get_parameters(self, e2e_port, lws_invoke):
+        # Arrange
+        param_name_1 = "/e2e/get-params-test-1"
+        param_name_2 = "/e2e/get-params-test-2"
+        expected_value_1 = "val1"
+        expected_value_2 = "val2"
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name_1,
+                "--value",
+                expected_value_1,
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name_2,
+                "--value",
+                expected_value_2,
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "ssm",
+                "get-parameters",
+                "--names",
+                json.dumps([param_name_1, param_name_2]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/ssm/test_list_tags_for_resource.py
+++ b/tests/e2e/ssm/test_list_tags_for_resource.py
@@ -1,0 +1,43 @@
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestListTagsForResource:
+    def test_list_tags_for_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        param_name = "/e2e/list-tags-test"
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name,
+                "--value",
+                "val1",
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "ssm",
+                "list-tags-for-resource",
+                "--resource-type",
+                "Parameter",
+                "--resource-id",
+                param_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/ssm/test_remove_tags_from_resource.py
+++ b/tests/e2e/ssm/test_remove_tags_from_resource.py
@@ -1,0 +1,61 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+
+class TestRemoveTagsFromResource:
+    def test_remove_tags_from_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        param_name = "/e2e/remove-tags-test"
+        lws_invoke(
+            [
+                "ssm",
+                "put-parameter",
+                "--name",
+                param_name,
+                "--value",
+                "val1",
+                "--type",
+                "String",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        lws_invoke(
+            [
+                "ssm",
+                "add-tags-to-resource",
+                "--resource-type",
+                "Parameter",
+                "--resource-id",
+                param_name,
+                "--tags",
+                json.dumps([{"Key": "env", "Value": "test"}]),
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "ssm",
+                "remove-tags-from-resource",
+                "--resource-type",
+                "Parameter",
+                "--resource-id",
+                param_name,
+                "--tag-keys",
+                json.dumps(["env"]),
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_get_execution_history.py
+++ b/tests/e2e/stepfunctions/test_get_execution_history.py
@@ -1,0 +1,58 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestGetExecutionHistory:
+    def test_get_execution_history(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-get-hist"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        start_output = lws_invoke(
+            [
+                "stepfunctions",
+                "start-execution",
+                "--name",
+                sm_name,
+                "--input",
+                "{}",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        execution_arn = start_output["executionArn"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "get-execution-history",
+                "--execution-arn",
+                execution_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_list_state_machine_versions.py
+++ b/tests/e2e/stepfunctions/test_list_state_machine_versions.py
@@ -1,0 +1,45 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestListStateMachineVersions:
+    def test_list_state_machine_versions(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-list-versions"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "list-state-machine-versions",
+                "--name",
+                sm_name,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_list_tags_for_resource.py
+++ b/tests/e2e/stepfunctions/test_list_tags_for_resource.py
@@ -1,0 +1,46 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestListTagsForResource:
+    def test_list_tags_for_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-list-tags-sm"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{sm_name}"
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "list-tags-for-resource",
+                "--resource-arn",
+                resource_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_start_sync_execution.py
+++ b/tests/e2e/stepfunctions/test_start_sync_execution.py
@@ -1,0 +1,47 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestStartSyncExecution:
+    def test_start_sync_execution(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-start-sync"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--type",
+                "EXPRESS",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "start-sync-execution",
+                "--name",
+                sm_name,
+                "--input",
+                "{}",
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_stop_execution.py
+++ b/tests/e2e/stepfunctions/test_stop_execution.py
@@ -1,0 +1,58 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestStopExecution:
+    def test_stop_execution(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-stop-exec"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        start_output = lws_invoke(
+            [
+                "stepfunctions",
+                "start-execution",
+                "--name",
+                sm_name,
+                "--input",
+                "{}",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        execution_arn = start_output["executionArn"]
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "stop-execution",
+                "--execution-arn",
+                execution_arn,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_tag_resource.py
+++ b/tests/e2e/stepfunctions/test_tag_resource.py
@@ -1,0 +1,49 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestTagResource:
+    def test_tag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-tag-sm"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{sm_name}"
+        tags = json.dumps([{"key": "env", "value": "test"}])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "tag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tags",
+                tags,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_untag_resource.py
+++ b/tests/e2e/stepfunctions/test_untag_resource.py
@@ -1,0 +1,62 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestUntagResource:
+    def test_untag_resource(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-untag-sm"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        resource_arn = f"arn:aws:states:us-east-1:000000000000:stateMachine:{sm_name}"
+        tags = json.dumps([{"key": "env", "value": "test"}])
+        lws_invoke(
+            [
+                "stepfunctions",
+                "tag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tags",
+                tags,
+                "--port",
+                str(e2e_port),
+            ]
+        )
+        tag_keys = json.dumps(["env"])
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "untag-resource",
+                "--resource-arn",
+                resource_arn,
+                "--tag-keys",
+                tag_keys,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_update_state_machine.py
+++ b/tests/e2e/stepfunctions/test_update_state_machine.py
@@ -1,0 +1,50 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+UPDATED_DEFINITION = json.dumps(
+    {"StartAt": "PassUpdated", "States": {"PassUpdated": {"Type": "Pass", "End": True}}}
+)
+
+
+class TestUpdateStateMachine:
+    def test_update_state_machine(self, e2e_port, lws_invoke):
+        # Arrange
+        sm_name = "e2e-update-sm"
+        lws_invoke(
+            [
+                "stepfunctions",
+                "create-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                PASS_DEFINITION,
+                "--role-arn",
+                "arn:aws:iam::000000000000:role/test",
+                "--port",
+                str(e2e_port),
+            ]
+        )
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "update-state-machine",
+                "--name",
+                sm_name,
+                "--definition",
+                UPDATED_DEFINITION,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/e2e/stepfunctions/test_validate_state_machine_definition.py
+++ b/tests/e2e/stepfunctions/test_validate_state_machine_definition.py
@@ -1,0 +1,31 @@
+import json
+
+from typer.testing import CliRunner
+
+from lws.cli.lws import app
+
+runner = CliRunner()
+
+PASS_DEFINITION = json.dumps({"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}})
+
+
+class TestValidateStateMachineDefinition:
+    def test_validate_state_machine_definition(self, e2e_port):
+        # Arrange
+        definition = PASS_DEFINITION
+
+        # Act
+        result = runner.invoke(
+            app,
+            [
+                "stepfunctions",
+                "validate-state-machine-definition",
+                "--definition",
+                definition,
+                "--port",
+                str(e2e_port),
+            ],
+        )
+
+        # Assert
+        assert result.exit_code == 0, result.output

--- a/tests/integration/apigateway/test_create_deployment.py
+++ b/tests/integration/apigateway/test_create_deployment.py
@@ -1,0 +1,24 @@
+"""Integration test for API Gateway CreateDeployment."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateDeployment:
+    async def test_create_deployment(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-create-deployment"})
+        api_id = create_resp.json()["id"]
+
+        # Act
+        response = await client.post(
+            f"/restapis/{api_id}/deployments",
+            json={},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "id" in body

--- a/tests/integration/apigateway/test_create_resource.py
+++ b/tests/integration/apigateway/test_create_resource.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway CreateResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateResource:
+    async def test_create_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-create-resource"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+
+        # Act
+        response = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "items"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_path = "/items"
+        actual_path = body["path"]
+        assert actual_path == expected_path
+        assert body["parentId"] == root_resource_id

--- a/tests/integration/apigateway/test_create_rest_api.py
+++ b/tests/integration/apigateway/test_create_rest_api.py
@@ -1,0 +1,27 @@
+"""Integration test for API Gateway CreateRestApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateRestApi:
+    async def test_create_rest_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        api_name = "int-create-rest-api"
+
+        # Act
+        response = await client.post(
+            "/restapis",
+            json={"name": api_name},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "id" in body
+        expected_name = api_name
+        actual_name = body["name"]
+        assert actual_name == expected_name
+        assert "rootResourceId" in body

--- a/tests/integration/apigateway/test_create_stage.py
+++ b/tests/integration/apigateway/test_create_stage.py
@@ -1,0 +1,28 @@
+"""Integration test for API Gateway CreateStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateStage:
+    async def test_create_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-create-stage"})
+        api_id = create_resp.json()["id"]
+        deploy_resp = await client.post(f"/restapis/{api_id}/deployments", json={})
+        deployment_id = deploy_resp.json()["id"]
+
+        # Act
+        response = await client.post(
+            f"/restapis/{api_id}/stages",
+            json={"stageName": "dev", "deploymentId": deployment_id},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "dev"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/apigateway/test_delete_integration.py
+++ b/tests/integration/apigateway/test_delete_integration.py
@@ -1,0 +1,36 @@
+"""Integration test for API Gateway DeleteIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteIntegration:
+    async def test_delete_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post("/restapis", json={"name": "int-del-integration"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "remove"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/POST",
+            json={"authorizationType": "NONE"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/POST/integration",
+            json={"type": "AWS_PROXY"},
+        )
+
+        # Act
+        response = await client.delete(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/POST/integration",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_delete_method.py
+++ b/tests/integration/apigateway/test_delete_method.py
@@ -1,0 +1,32 @@
+"""Integration test for API Gateway DeleteMethod."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteMethod:
+    async def test_delete_method(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post("/restapis", json={"name": "int-delete-method"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "temp"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/DELETE",
+            json={"authorizationType": "NONE"},
+        )
+
+        # Act
+        response = await client.delete(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/DELETE",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_delete_resource.py
+++ b/tests/integration/apigateway/test_delete_resource.py
@@ -1,0 +1,26 @@
+"""Integration test for API Gateway DeleteResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteResource:
+    async def test_delete_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 202
+        create_resp = await client.post("/restapis", json={"name": "int-delete-resource"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "to-delete"},
+        )
+        resource_id = resource_resp.json()["id"]
+
+        # Act
+        response = await client.delete(f"/restapis/{api_id}/resources/{resource_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_delete_rest_api.py
+++ b/tests/integration/apigateway/test_delete_rest_api.py
@@ -1,0 +1,24 @@
+"""Integration test for API Gateway DeleteRestApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteRestApi:
+    async def test_delete_rest_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 202
+        create_resp = await client.post("/restapis", json={"name": "int-delete-rest-api"})
+        api_id = create_resp.json()["id"]
+
+        # Act
+        response = await client.delete(f"/restapis/{api_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+
+        # Verify deleted
+        get_resp = await client.get(f"/restapis/{api_id}")
+        expected_get_status = 404
+        assert get_resp.status_code == expected_get_status

--- a/tests/integration/apigateway/test_delete_stage.py
+++ b/tests/integration/apigateway/test_delete_stage.py
@@ -1,0 +1,25 @@
+"""Integration test for API Gateway DeleteStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteStage:
+    async def test_delete_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 202
+        create_resp = await client.post("/restapis", json={"name": "int-delete-stage"})
+        api_id = create_resp.json()["id"]
+        deploy_resp = await client.post(f"/restapis/{api_id}/deployments", json={})
+        deployment_id = deploy_resp.json()["id"]
+        await client.post(
+            f"/restapis/{api_id}/stages",
+            json={"stageName": "to-delete", "deploymentId": deployment_id},
+        )
+
+        # Act
+        response = await client.delete(f"/restapis/{api_id}/stages/to-delete")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_get_deployment.py
+++ b/tests/integration/apigateway/test_get_deployment.py
@@ -1,0 +1,25 @@
+"""Integration test for API Gateway GetDeployment."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetDeployment:
+    async def test_get_deployment(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-deployment"})
+        api_id = create_resp.json()["id"]
+        deploy_resp = await client.post(f"/restapis/{api_id}/deployments", json={})
+        deployment_id = deploy_resp.json()["id"]
+
+        # Act
+        response = await client.get(f"/restapis/{api_id}/deployments/{deployment_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_id = deployment_id
+        actual_id = body["id"]
+        assert actual_id == expected_id

--- a/tests/integration/apigateway/test_get_integration.py
+++ b/tests/integration/apigateway/test_get_integration.py
@@ -1,0 +1,40 @@
+"""Integration test for API Gateway GetIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetIntegration:
+    async def test_get_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-integration"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "data"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET",
+            json={"authorizationType": "NONE"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/integration",
+            json={"type": "AWS_PROXY"},
+        )
+
+        # Act
+        response = await client.get(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/integration",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_type = "AWS_PROXY"
+        actual_type = body["type"]
+        assert actual_type == expected_type

--- a/tests/integration/apigateway/test_get_integration_response.py
+++ b/tests/integration/apigateway/test_get_integration_response.py
@@ -1,0 +1,44 @@
+"""Integration test for API Gateway GetIntegrationResponse."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetIntegrationResponse:
+    async def test_get_integration_response(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-int-resp"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "getresp"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET",
+            json={"authorizationType": "NONE"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/integration",
+            json={"type": "MOCK"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET" "/integration/responses/200",
+            json={"statusCode": "200"},
+        )
+
+        # Act
+        response = await client.get(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET" "/integration/responses/200",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_sc = "200"
+        actual_sc = body["statusCode"]
+        assert actual_sc == expected_sc

--- a/tests/integration/apigateway/test_get_method.py
+++ b/tests/integration/apigateway/test_get_method.py
@@ -1,0 +1,36 @@
+"""Integration test for API Gateway GetMethod."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetMethod:
+    async def test_get_method(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_http_method = "GET"
+        create_resp = await client.post("/restapis", json={"name": "int-get-method"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "products"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/{expected_http_method}",
+            json={"authorizationType": "NONE"},
+        )
+
+        # Act
+        response = await client.get(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/{expected_http_method}",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        actual_http_method = body["httpMethod"]
+        assert actual_http_method == expected_http_method

--- a/tests/integration/apigateway/test_get_method_response.py
+++ b/tests/integration/apigateway/test_get_method_response.py
@@ -1,0 +1,40 @@
+"""Integration test for API Gateway GetMethodResponse."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetMethodResponse:
+    async def test_get_method_response(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-method-resp"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "gmresp"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET",
+            json={"authorizationType": "NONE"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/responses/200",
+            json={"statusCode": "200"},
+        )
+
+        # Act
+        response = await client.get(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/responses/200",
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_sc = "200"
+        actual_sc = body["statusCode"]
+        assert actual_sc == expected_sc

--- a/tests/integration/apigateway/test_get_resources.py
+++ b/tests/integration/apigateway/test_get_resources.py
@@ -1,0 +1,25 @@
+"""Integration test for API Gateway GetResources."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetResources:
+    async def test_get_resources(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-resources"})
+        api_id = create_resp.json()["id"]
+
+        # Act
+        response = await client.get(f"/restapis/{api_id}/resources")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "item" in body
+        assert len(body["item"]) >= 1
+        expected_root_path = "/"
+        actual_root_path = body["item"][0]["path"]
+        assert actual_root_path == expected_root_path

--- a/tests/integration/apigateway/test_get_rest_api.py
+++ b/tests/integration/apigateway/test_get_rest_api.py
@@ -1,0 +1,33 @@
+"""Integration test for API Gateway GetRestApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetRestApi:
+    async def test_get_rest_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-rest-api"})
+        api_id = create_resp.json()["id"]
+
+        # Act
+        response = await client.get(f"/restapis/{api_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_name = "int-get-rest-api"
+        actual_name = body["name"]
+        assert actual_name == expected_name
+
+    async def test_get_rest_api_not_found(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+
+        # Act
+        response = await client.get("/restapis/nonexistent")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_get_stage.py
+++ b/tests/integration/apigateway/test_get_stage.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway GetStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetStage:
+    async def test_get_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-get-stage"})
+        api_id = create_resp.json()["id"]
+        deploy_resp = await client.post(f"/restapis/{api_id}/deployments", json={})
+        deployment_id = deploy_resp.json()["id"]
+        await client.post(
+            f"/restapis/{api_id}/stages",
+            json={"stageName": "staging", "deploymentId": deployment_id},
+        )
+
+        # Act
+        response = await client.get(f"/restapis/{api_id}/stages/staging")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "staging"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/apigateway/test_list_deployments.py
+++ b/tests/integration/apigateway/test_list_deployments.py
@@ -1,0 +1,23 @@
+"""Integration test for API Gateway ListDeployments."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListDeployments:
+    async def test_list_deployments(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-list-deployments"})
+        api_id = create_resp.json()["id"]
+        await client.post(f"/restapis/{api_id}/deployments", json={})
+
+        # Act
+        response = await client.get(f"/restapis/{api_id}/deployments")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "item" in body
+        assert len(body["item"]) >= 1

--- a/tests/integration/apigateway/test_list_rest_apis.py
+++ b/tests/integration/apigateway/test_list_rest_apis.py
@@ -1,0 +1,21 @@
+"""Integration test for API Gateway ListRestApis."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListRestApis:
+    async def test_list_rest_apis(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        await client.post("/restapis", json={"name": "int-list-rest-apis"})
+
+        # Act
+        response = await client.get("/restapis")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "item" in body
+        assert len(body["item"]) >= 1

--- a/tests/integration/apigateway/test_put_integration.py
+++ b/tests/integration/apigateway/test_put_integration.py
@@ -1,0 +1,37 @@
+"""Integration test for API Gateway PutIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestPutIntegration:
+    async def test_put_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-put-integration"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "items"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/POST",
+            json={"authorizationType": "NONE"},
+        )
+
+        # Act
+        response = await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/POST/integration",
+            json={"type": "AWS_PROXY", "uri": "arn:aws:lambda:us-east-1:000:function:test"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_type = "AWS_PROXY"
+        actual_type = body["type"]
+        assert actual_type == expected_type

--- a/tests/integration/apigateway/test_put_integration_response.py
+++ b/tests/integration/apigateway/test_put_integration_response.py
@@ -1,0 +1,41 @@
+"""Integration test for API Gateway PutIntegrationResponse."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestPutIntegrationResponse:
+    async def test_put_integration_response(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-put-int-resp"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "resp"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET",
+            json={"authorizationType": "NONE"},
+        )
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/integration",
+            json={"type": "MOCK"},
+        )
+
+        # Act
+        response = await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET" "/integration/responses/200",
+            json={"statusCode": "200"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_sc = "200"
+        actual_sc = body["statusCode"]
+        assert actual_sc == expected_sc

--- a/tests/integration/apigateway/test_put_method.py
+++ b/tests/integration/apigateway/test_put_method.py
@@ -1,0 +1,33 @@
+"""Integration test for API Gateway PutMethod."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestPutMethod:
+    async def test_put_method(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        expected_http_method = "GET"
+        create_resp = await client.post("/restapis", json={"name": "int-put-method"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "orders"},
+        )
+        resource_id = resource_resp.json()["id"]
+
+        # Act
+        response = await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/{expected_http_method}",
+            json={"authorizationType": "NONE"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        actual_http_method = body["httpMethod"]
+        assert actual_http_method == expected_http_method

--- a/tests/integration/apigateway/test_put_method_response.py
+++ b/tests/integration/apigateway/test_put_method_response.py
@@ -1,0 +1,37 @@
+"""Integration test for API Gateway PutMethodResponse."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestPutMethodResponse:
+    async def test_put_method_response(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post("/restapis", json={"name": "int-put-method-resp"})
+        api_body = create_resp.json()
+        api_id = api_body["id"]
+        root_resource_id = api_body["rootResourceId"]
+        resource_resp = await client.post(
+            f"/restapis/{api_id}/resources/{root_resource_id}",
+            json={"pathPart": "mresp"},
+        )
+        resource_id = resource_resp.json()["id"]
+        await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET",
+            json={"authorizationType": "NONE"},
+        )
+
+        # Act
+        response = await client.put(
+            f"/restapis/{api_id}/resources/{resource_id}/methods/GET/responses/200",
+            json={"statusCode": "200"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_sc = "200"
+        actual_sc = body["statusCode"]
+        assert actual_sc == expected_sc

--- a/tests/integration/apigateway/test_update_rest_api.py
+++ b/tests/integration/apigateway/test_update_rest_api.py
@@ -1,0 +1,30 @@
+"""Integration test for API Gateway UpdateRestApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateRestApi:
+    async def test_update_rest_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-update-rest-api"})
+        api_id = create_resp.json()["id"]
+
+        # Act
+        response = await client.patch(
+            f"/restapis/{api_id}",
+            json={
+                "patchOperations": [
+                    {"op": "replace", "path": "/name", "value": "int-updated"},
+                ]
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_name = "int-updated"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/integration/apigateway/test_update_stage.py
+++ b/tests/integration/apigateway/test_update_stage.py
@@ -1,0 +1,32 @@
+"""Integration test for API Gateway UpdateStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateStage:
+    async def test_update_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post("/restapis", json={"name": "int-update-stage"})
+        api_id = create_resp.json()["id"]
+        deploy_resp = await client.post(f"/restapis/{api_id}/deployments", json={})
+        deployment_id = deploy_resp.json()["id"]
+        await client.post(
+            f"/restapis/{api_id}/stages",
+            json={"stageName": "prod", "deploymentId": deployment_id},
+        )
+
+        # Act
+        response = await client.patch(
+            f"/restapis/{api_id}/stages/prod",
+            json={"patchOperations": []},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "prod"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/apigateway/test_v2_create_api.py
+++ b/tests/integration/apigateway/test_v2_create_api.py
@@ -1,0 +1,26 @@
+"""Integration test for API Gateway V2 CreateApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2CreateApi:
+    async def test_v2_create_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        api_name = "int-v2-create-api"
+
+        # Act
+        response = await client.post(
+            "/v2/apis",
+            json={"Name": api_name, "ProtocolType": "HTTP"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "apiId" in body
+        expected_name = api_name
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/integration/apigateway/test_v2_create_integration.py
+++ b/tests/integration/apigateway/test_v2_create_integration.py
@@ -1,0 +1,30 @@
+"""Integration test for API Gateway V2 CreateIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2CreateIntegration:
+    async def test_v2_create_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-create-int", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.post(
+            f"/v2/apis/{api_id}/integrations",
+            json={"IntegrationType": "AWS_PROXY"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "integrationId" in body
+        expected_type = "AWS_PROXY"
+        actual_type = body["integrationType"]
+        assert actual_type == expected_type

--- a/tests/integration/apigateway/test_v2_create_route.py
+++ b/tests/integration/apigateway/test_v2_create_route.py
@@ -1,0 +1,30 @@
+"""Integration test for API Gateway V2 CreateRoute."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2CreateRoute:
+    async def test_v2_create_route(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-create-route", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.post(
+            f"/v2/apis/{api_id}/routes",
+            json={"RouteKey": "GET /items"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "routeId" in body
+        expected_route_key = "GET /items"
+        actual_route_key = body["routeKey"]
+        assert actual_route_key == expected_route_key

--- a/tests/integration/apigateway/test_v2_create_stage.py
+++ b/tests/integration/apigateway/test_v2_create_stage.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway V2 CreateStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2CreateStage:
+    async def test_v2_create_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-create-stage", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.post(
+            f"/v2/apis/{api_id}/stages",
+            json={"StageName": "dev"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "dev"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/apigateway/test_v2_delete_api.py
+++ b/tests/integration/apigateway/test_v2_delete_api.py
@@ -1,0 +1,27 @@
+"""Integration test for API Gateway V2 DeleteApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2DeleteApi:
+    async def test_v2_delete_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-delete-api", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.delete(f"/v2/apis/{api_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+
+        # Verify deleted
+        get_resp = await client.get(f"/v2/apis/{api_id}")
+        expected_get_status = 404
+        assert get_resp.status_code == expected_get_status

--- a/tests/integration/apigateway/test_v2_delete_integration.py
+++ b/tests/integration/apigateway/test_v2_delete_integration.py
@@ -1,0 +1,27 @@
+"""Integration test for API Gateway V2 DeleteIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2DeleteIntegration:
+    async def test_v2_delete_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-del-int", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        int_resp = await client.post(
+            f"/v2/apis/{api_id}/integrations",
+            json={"IntegrationType": "AWS_PROXY"},
+        )
+        integration_id = int_resp.json()["integrationId"]
+
+        # Act
+        response = await client.delete(f"/v2/apis/{api_id}/integrations/{integration_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_v2_delete_route.py
+++ b/tests/integration/apigateway/test_v2_delete_route.py
@@ -1,0 +1,27 @@
+"""Integration test for API Gateway V2 DeleteRoute."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2DeleteRoute:
+    async def test_v2_delete_route(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-del-route", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        route_resp = await client.post(
+            f"/v2/apis/{api_id}/routes",
+            json={"RouteKey": "DELETE /temp"},
+        )
+        route_id = route_resp.json()["routeId"]
+
+        # Act
+        response = await client.delete(f"/v2/apis/{api_id}/routes/{route_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_v2_delete_stage.py
+++ b/tests/integration/apigateway/test_v2_delete_stage.py
@@ -1,0 +1,26 @@
+"""Integration test for API Gateway V2 DeleteStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2DeleteStage:
+    async def test_v2_delete_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-delete-stage", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/stages",
+            json={"StageName": "to-delete"},
+        )
+
+        # Act
+        response = await client.delete(f"/v2/apis/{api_id}/stages/to-delete")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_v2_get_api.py
+++ b/tests/integration/apigateway/test_v2_get_api.py
@@ -1,0 +1,36 @@
+"""Integration test for API Gateway V2 GetApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2GetApi:
+    async def test_v2_get_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-get-api", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_name = "int-v2-get-api"
+        actual_name = body["name"]
+        assert actual_name == expected_name
+
+    async def test_v2_get_api_not_found(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+
+        # Act
+        response = await client.get("/v2/apis/nonexistent")
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/apigateway/test_v2_get_integration.py
+++ b/tests/integration/apigateway/test_v2_get_integration.py
@@ -1,0 +1,31 @@
+"""Integration test for API Gateway V2 GetIntegration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2GetIntegration:
+    async def test_v2_get_integration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-get-int", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        int_resp = await client.post(
+            f"/v2/apis/{api_id}/integrations",
+            json={"IntegrationType": "AWS_PROXY"},
+        )
+        integration_id = int_resp.json()["integrationId"]
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/integrations/{integration_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_id = integration_id
+        actual_id = body["integrationId"]
+        assert actual_id == expected_id

--- a/tests/integration/apigateway/test_v2_get_route.py
+++ b/tests/integration/apigateway/test_v2_get_route.py
@@ -1,0 +1,31 @@
+"""Integration test for API Gateway V2 GetRoute."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2GetRoute:
+    async def test_v2_get_route(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-get-route", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        route_resp = await client.post(
+            f"/v2/apis/{api_id}/routes",
+            json={"RouteKey": "POST /data"},
+        )
+        route_id = route_resp.json()["routeId"]
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/routes/{route_id}")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_route_key = "POST /data"
+        actual_route_key = body["routeKey"]
+        assert actual_route_key == expected_route_key

--- a/tests/integration/apigateway/test_v2_get_stage.py
+++ b/tests/integration/apigateway/test_v2_get_stage.py
@@ -1,0 +1,30 @@
+"""Integration test for API Gateway V2 GetStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2GetStage:
+    async def test_v2_get_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-get-stage", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/stages",
+            json={"StageName": "staging"},
+        )
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/stages/staging")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "staging"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/apigateway/test_v2_list_apis.py
+++ b/tests/integration/apigateway/test_v2_list_apis.py
@@ -1,0 +1,24 @@
+"""Integration test for API Gateway V2 ListApis."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2ListApis:
+    async def test_v2_list_apis(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-list-apis", "ProtocolType": "HTTP"},
+        )
+
+        # Act
+        response = await client.get("/v2/apis")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/integration/apigateway/test_v2_list_integrations.py
+++ b/tests/integration/apigateway/test_v2_list_integrations.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway V2 ListIntegrations."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2ListIntegrations:
+    async def test_v2_list_integrations(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-list-ints", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/integrations",
+            json={"IntegrationType": "AWS_PROXY"},
+        )
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/integrations")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/integration/apigateway/test_v2_list_routes.py
+++ b/tests/integration/apigateway/test_v2_list_routes.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway V2 ListRoutes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2ListRoutes:
+    async def test_v2_list_routes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-list-routes", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/routes",
+            json={"RouteKey": "GET /orders"},
+        )
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/routes")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/integration/apigateway/test_v2_list_stages.py
+++ b/tests/integration/apigateway/test_v2_list_stages.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway V2 ListStages."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2ListStages:
+    async def test_v2_list_stages(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-list-stages", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/stages",
+            json={"StageName": "test"},
+        )
+
+        # Act
+        response = await client.get(f"/v2/apis/{api_id}/stages")
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        assert "items" in body
+        assert len(body["items"]) >= 1

--- a/tests/integration/apigateway/test_v2_update_api.py
+++ b/tests/integration/apigateway/test_v2_update_api.py
@@ -1,0 +1,29 @@
+"""Integration test for API Gateway V2 UpdateApi."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2UpdateApi:
+    async def test_v2_update_api(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-update-api", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+
+        # Act
+        response = await client.patch(
+            f"/v2/apis/{api_id}",
+            json={"Name": "int-v2-updated"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_name = "int-v2-updated"
+        actual_name = body["name"]
+        assert actual_name == expected_name

--- a/tests/integration/apigateway/test_v2_update_stage.py
+++ b/tests/integration/apigateway/test_v2_update_stage.py
@@ -1,0 +1,33 @@
+"""Integration test for API Gateway V2 UpdateStage."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestV2UpdateStage:
+    async def test_v2_update_stage(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        create_resp = await client.post(
+            "/v2/apis",
+            json={"Name": "int-v2-update-stage", "ProtocolType": "HTTP"},
+        )
+        api_id = create_resp.json()["apiId"]
+        await client.post(
+            f"/v2/apis/{api_id}/stages",
+            json={"StageName": "prod"},
+        )
+
+        # Act
+        response = await client.patch(
+            f"/v2/apis/{api_id}/stages/prod",
+            json={},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code
+        body = response.json()
+        expected_stage_name = "prod"
+        actual_stage_name = body["stageName"]
+        assert actual_stage_name == expected_stage_name

--- a/tests/integration/cognito_idp/test_admin_create_user.py
+++ b/tests/integration/cognito_idp/test_admin_create_user.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito AdminCreateUser."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestAdminCreateUser:
+    async def test_admin_create_user(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminCreateUser",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "Username": "admin-test-user"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_admin_delete_user.py
+++ b/tests/integration/cognito_idp/test_admin_delete_user.py
@@ -1,0 +1,33 @@
+"""Integration test for Cognito AdminDeleteUser."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestAdminDeleteUser:
+    async def test_admin_delete_user(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminCreateUser",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "Username": "admin-del-user"},
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminDeleteUser",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "Username": "admin-del-user"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_admin_get_user.py
+++ b/tests/integration/cognito_idp/test_admin_get_user.py
@@ -1,0 +1,41 @@
+"""Integration test for Cognito AdminGetUser."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestAdminGetUser:
+    async def test_admin_get_user(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        username = "admin-get-user"
+        password = "Password1!"
+        client_id = "test-client"
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "Password": password,
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminGetUser",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "Username": username},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_change_password.py
+++ b/tests/integration/cognito_idp/test_change_password.py
@@ -1,0 +1,75 @@
+"""Integration test for Cognito ChangePassword."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestChangePassword:
+    async def test_change_password(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        client_id = "test-client"
+        username = "change-pw-user"
+        password = "Password1!"
+        new_password = "NewPassword1!"
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "Password": password,
+            },
+        )
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "ConfirmationCode": "123456",
+            },
+        )
+
+        auth_resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "AuthFlow": "USER_PASSWORD_AUTH",
+                "ClientId": client_id,
+                "AuthParameters": {
+                    "USERNAME": username,
+                    "PASSWORD": password,
+                },
+            },
+        )
+        access_token = auth_resp.json()["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ChangePassword",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "AccessToken": access_token,
+                "PreviousPassword": password,
+                "ProposedPassword": new_password,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_confirm_forgot_password.py
+++ b/tests/integration/cognito_idp/test_confirm_forgot_password.py
@@ -1,0 +1,45 @@
+"""Integration test for Cognito ConfirmForgotPassword."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestConfirmForgotPassword:
+    async def test_confirm_forgot_password_bad_code(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 400
+        client_id = "test-client"
+        username = "confirm-forgot-user"
+        password = "Password1!"
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "Password": password,
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "ConfirmationCode": "000000",
+                "Password": "NewPassword1!",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_create_user_pool_client.py
+++ b/tests/integration/cognito_idp/test_create_user_pool_client.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito CreateUserPoolClient."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateUserPoolClient:
+    async def test_create_user_pool_client(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateUserPoolClient",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "ClientName": "new-client"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_delete_user_pool_client.py
+++ b/tests/integration/cognito_idp/test_delete_user_pool_client.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito DeleteUserPoolClient."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteUserPoolClient:
+    async def test_delete_user_pool_client(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 400
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "ClientId": "test-client"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_describe_user_pool_client.py
+++ b/tests/integration/cognito_idp/test_describe_user_pool_client.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito DescribeUserPoolClient."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDescribeUserPoolClient:
+    async def test_describe_user_pool_client(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 400
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "ClientId": "test-client"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_forgot_password.py
+++ b/tests/integration/cognito_idp/test_forgot_password.py
@@ -1,0 +1,43 @@
+"""Integration test for Cognito ForgotPassword."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestForgotPassword:
+    async def test_forgot_password(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        client_id = "test-client"
+        username = "forgot-pw-user"
+        password = "Password1!"
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "Password": password,
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgotPassword",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_global_sign_out.py
+++ b/tests/integration/cognito_idp/test_global_sign_out.py
@@ -1,0 +1,72 @@
+"""Integration test for Cognito GlobalSignOut."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGlobalSignOut:
+    async def test_global_sign_out(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        client_id = "test-client"
+        username = "signout-user"
+        password = "Password1!"
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "Password": password,
+            },
+        )
+
+        await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "ClientId": client_id,
+                "Username": username,
+                "ConfirmationCode": "123456",
+            },
+        )
+
+        auth_resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "AuthFlow": "USER_PASSWORD_AUTH",
+                "ClientId": client_id,
+                "AuthParameters": {
+                    "USERNAME": username,
+                    "PASSWORD": password,
+                },
+            },
+        )
+        access_token = auth_resp.json()["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.GlobalSignOut",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={
+                "AccessToken": access_token,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_list_user_pool_clients.py
+++ b/tests/integration/cognito_idp/test_list_user_pool_clients.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito ListUserPoolClients."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListUserPoolClients:
+    async def test_list_user_pool_clients(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUserPoolClients",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "MaxResults": 60},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_list_users.py
+++ b/tests/integration/cognito_idp/test_list_users.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito ListUsers."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListUsers:
+    async def test_list_users(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUsers",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool", "Limit": 60},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/cognito_idp/test_update_user_pool.py
+++ b/tests/integration/cognito_idp/test_update_user_pool.py
@@ -1,0 +1,25 @@
+"""Integration test for Cognito UpdateUserPool."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateUserPool:
+    async def test_update_user_pool(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateUserPool",
+                "Content-Type": "application/x-amz-json-1.1",
+            },
+            json={"UserPoolId": "us-east-1_TestPool"},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/dynamodb/test_batch_get_item.py
+++ b/tests/integration/dynamodb/test_batch_get_item.py
@@ -1,0 +1,31 @@
+"""Integration test for DynamoDB BatchGetItem."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestBatchGetItem:
+    async def test_batch_get_item(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        table_name = "TestTable"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.PutItem"},
+            json={
+                "TableName": table_name,
+                "Item": {"pk": {"S": "bg1"}, "data": {"S": "hello"}},
+            },
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.BatchGetItem"},
+            json={"RequestItems": {table_name: {"Keys": [{"pk": {"S": "bg1"}}]}}},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/dynamodb/test_batch_write_item.py
+++ b/tests/integration/dynamodb/test_batch_write_item.py
@@ -1,0 +1,29 @@
+"""Integration test for DynamoDB BatchWriteItem."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestBatchWriteItem:
+    async def test_batch_write_item(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        table_name = "TestTable"
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.BatchWriteItem"},
+            json={
+                "RequestItems": {
+                    table_name: [
+                        {"PutRequest": {"Item": {"pk": {"S": "bw1"}, "data": {"S": "val1"}}}},
+                        {"PutRequest": {"Item": {"pk": {"S": "bw2"}, "data": {"S": "val2"}}}},
+                    ]
+                }
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/dynamodb/test_transact_get_items.py
+++ b/tests/integration/dynamodb/test_transact_get_items.py
@@ -1,0 +1,40 @@
+"""Integration test for DynamoDB TransactGetItems."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTransactGetItems:
+    async def test_transact_get_items(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        table_name = "TestTable"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.PutItem"},
+            json={
+                "TableName": table_name,
+                "Item": {"pk": {"S": "tg1"}, "data": {"S": "value"}},
+            },
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.TransactGetItems"},
+            json={
+                "TransactItems": [
+                    {
+                        "Get": {
+                            "TableName": table_name,
+                            "Key": {"pk": {"S": "tg1"}},
+                        }
+                    }
+                ]
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/dynamodb/test_transact_write_items.py
+++ b/tests/integration/dynamodb/test_transact_write_items.py
@@ -1,0 +1,36 @@
+"""Integration test for DynamoDB TransactWriteItems."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTransactWriteItems:
+    async def test_transact_write_items_puts_item(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        table_name = "TestTable"
+        expected_pk = {"S": "txn-item-1"}
+        expected_data = {"S": "transact-data"}
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.TransactWriteItems"},
+            json={
+                "TransactItems": [
+                    {
+                        "Put": {
+                            "TableName": table_name,
+                            "Item": {
+                                "pk": expected_pk,
+                                "data": expected_data,
+                            },
+                        }
+                    }
+                ]
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/dynamodb/test_update_item.py
+++ b/tests/integration/dynamodb/test_update_item.py
@@ -1,0 +1,37 @@
+"""Integration test for DynamoDB UpdateItem."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateItem:
+    async def test_update_item(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        table_name = "TestTable"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.PutItem"},
+            json={
+                "TableName": table_name,
+                "Item": {"pk": {"S": "upd1"}, "data": {"S": "original"}},
+            },
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "DynamoDB_20120810.UpdateItem"},
+            json={
+                "TableName": table_name,
+                "Key": {"pk": {"S": "upd1"}},
+                "UpdateExpression": "SET #d = :val",
+                "ExpressionAttributeValues": {":val": {"S": "updated"}},
+                "ExpressionAttributeNames": {"#d": "data"},
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/events/test_describe_event_bus.py
+++ b/tests/integration/events/test_describe_event_bus.py
@@ -1,0 +1,22 @@
+"""Integration test for EventBridge DescribeEventBus."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDescribeEventBus:
+    async def test_describe_event_bus(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_bus_name = "default"
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.DescribeEventBus"},
+            json={"Name": expected_bus_name},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_describe_rule.py
+++ b/tests/integration/events/test_describe_rule.py
@@ -1,0 +1,34 @@
+"""Integration test for EventBridge DescribeRule."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestDescribeRule:
+    async def test_describe_rule(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "describe-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.DescribeRule"},
+            json={"Name": expected_rule_name, "EventBusName": "default"},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_disable_rule.py
+++ b/tests/integration/events/test_disable_rule.py
@@ -1,0 +1,34 @@
+"""Integration test for EventBridge DisableRule."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestDisableRule:
+    async def test_disable_rule(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "disable-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.DisableRule"},
+            json={"Name": expected_rule_name, "EventBusName": "default"},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_enable_rule.py
+++ b/tests/integration/events/test_enable_rule.py
@@ -1,0 +1,34 @@
+"""Integration test for EventBridge EnableRule."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestEnableRule:
+    async def test_enable_rule(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "enable-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.EnableRule"},
+            json={"Name": expected_rule_name, "EventBusName": "default"},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_list_tags_for_resource.py
+++ b/tests/integration/events/test_list_tags_for_resource.py
@@ -1,0 +1,22 @@
+"""Integration test for EventBridge ListTagsForResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListTagsForResource:
+    async def test_list_tags_for_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:events:us-east-1:123456789012:event-bus/default"
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.ListTagsForResource"},
+            json={"ResourceARN": expected_resource_arn},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_list_targets_by_rule.py
+++ b/tests/integration/events/test_list_targets_by_rule.py
@@ -1,0 +1,34 @@
+"""Integration test for EventBridge ListTargetsByRule."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestListTargetsByRule:
+    async def test_list_targets_by_rule(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "list-targets-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.ListTargetsByRule"},
+            json={"Rule": expected_rule_name, "EventBusName": "default"},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_put_targets.py
+++ b/tests/integration/events/test_put_targets.py
@@ -1,0 +1,40 @@
+"""Integration test for EventBridge PutTargets."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestPutTargets:
+    async def test_put_targets(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "targets-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutTargets"},
+            json={
+                "Rule": expected_rule_name,
+                "Targets": [
+                    {"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn"}
+                ],
+                "EventBusName": "default",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_remove_targets.py
+++ b/tests/integration/events/test_remove_targets.py
@@ -1,0 +1,49 @@
+"""Integration test for EventBridge RemoveTargets."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestRemoveTargets:
+    async def test_remove_targets(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_rule_name = "rm-targets-rule"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutRule"},
+            json={
+                "Name": expected_rule_name,
+                "EventBusName": "default",
+                "EventPattern": json.dumps({"source": ["my.app"]}),
+            },
+        )
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.PutTargets"},
+            json={
+                "Rule": expected_rule_name,
+                "Targets": [
+                    {"Id": "t1", "Arn": "arn:aws:lambda:us-east-1:000000000000:function:fn"}
+                ],
+                "EventBusName": "default",
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.RemoveTargets"},
+            json={
+                "Rule": expected_rule_name,
+                "Ids": ["t1"],
+                "EventBusName": "default",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_tag_resource.py
+++ b/tests/integration/events/test_tag_resource.py
@@ -1,0 +1,25 @@
+"""Integration test for EventBridge TagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTagResource:
+    async def test_tag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:events:us-east-1:123456789012:event-bus/default"
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.TagResource"},
+            json={
+                "ResourceARN": expected_resource_arn,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/events/test_untag_resource.py
+++ b/tests/integration/events/test_untag_resource.py
@@ -1,0 +1,34 @@
+"""Integration test for EventBridge UntagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUntagResource:
+    async def test_untag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:events:us-east-1:123456789012:event-bus/default"
+
+        await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.TagResource"},
+            json={
+                "ResourceARN": expected_resource_arn,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSEvents.UntagResource"},
+            json={
+                "ResourceARN": expected_resource_arn,
+                "TagKeys": ["env"],
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/lambda_/test_create_event_source_mapping.py
+++ b/tests/integration/lambda_/test_create_event_source_mapping.py
@@ -1,0 +1,26 @@
+"""Integration test for Lambda CreateEventSourceMapping."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateEventSourceMapping:
+    async def test_create_event_source_mapping(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 202
+        expected_function_name = "esm-function"
+        expected_event_source_arn = "arn:aws:sqs:us-east-1:123456789012:test-queue"
+
+        # Act
+        resp = await client.post(
+            "/2015-03-31/event-source-mappings",
+            json={
+                "FunctionName": expected_function_name,
+                "EventSourceArn": expected_event_source_arn,
+            },
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_create_function.py
+++ b/tests/integration/lambda_/test_create_function.py
@@ -1,0 +1,30 @@
+"""Integration test for Lambda CreateFunction."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateFunction:
+    async def test_create_function_returns_response(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 201
+        expected_function_name = "test-function"
+
+        # Act
+        resp = await client.post(
+            "/2015-03-31/functions",
+            json={
+                "FunctionName": expected_function_name,
+                "Runtime": "python3.12",
+                "Role": "arn:aws:iam::123456789012:role/test-role",
+                "Handler": "index.handler",
+                "Code": {"ZipFile": ""},
+            },
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code
+        actual_body = resp.json()
+        assert actual_body["FunctionName"] == expected_function_name

--- a/tests/integration/lambda_/test_delete_event_source_mapping.py
+++ b/tests/integration/lambda_/test_delete_event_source_mapping.py
@@ -1,0 +1,21 @@
+"""Integration test for Lambda DeleteEventSourceMapping."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteEventSourceMapping:
+    async def test_delete_nonexistent_event_source_mapping(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+        expected_uuid = "nonexistent-uuid"
+
+        # Act
+        resp = await client.delete(
+            f"/2015-03-31/event-source-mappings/{expected_uuid}",
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_delete_function.py
+++ b/tests/integration/lambda_/test_delete_function.py
@@ -1,0 +1,18 @@
+"""Integration test for Lambda DeleteFunction."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteFunction:
+    async def test_delete_nonexistent_function(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+
+        # Act
+        resp = await client.delete("/2015-03-31/functions/nonexistent")
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_get_function.py
+++ b/tests/integration/lambda_/test_get_function.py
@@ -1,0 +1,18 @@
+"""Integration test for Lambda GetFunction."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetFunction:
+    async def test_get_nonexistent_function(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+
+        # Act
+        resp = await client.get("/2015-03-31/functions/nonexistent")
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_list_event_source_mappings.py
+++ b/tests/integration/lambda_/test_list_event_source_mappings.py
@@ -1,0 +1,18 @@
+"""Integration test for Lambda ListEventSourceMappings."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListEventSourceMappings:
+    async def test_list_event_source_mappings(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.get("/2015-03-31/event-source-mappings")
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_list_functions.py
+++ b/tests/integration/lambda_/test_list_functions.py
@@ -1,0 +1,18 @@
+"""Integration test for Lambda ListFunctions."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListFunctions:
+    async def test_list_functions(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.get("/2015-03-31/functions")
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_update_function_code.py
+++ b/tests/integration/lambda_/test_update_function_code.py
@@ -1,0 +1,21 @@
+"""Integration test for Lambda UpdateFunctionCode."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateFunctionCode:
+    async def test_update_nonexistent_function_code(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+
+        # Act
+        resp = await client.put(
+            "/2015-03-31/functions/nonexistent/code",
+            json={"ZipFile": ""},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/lambda_/test_update_function_configuration.py
+++ b/tests/integration/lambda_/test_update_function_configuration.py
@@ -1,0 +1,21 @@
+"""Integration test for Lambda UpdateFunctionConfiguration."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateFunctionConfiguration:
+    async def test_update_nonexistent_function_configuration(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 404
+
+        # Act
+        resp = await client.put(
+            "/2015-03-31/functions/nonexistent/configuration",
+            json={"FunctionName": "nonexistent", "Timeout": 60},
+        )
+
+        # Assert
+        actual_status_code = resp.status_code
+        assert actual_status_code == expected_status_code

--- a/tests/integration/s3api/test_abort_multipart_upload.py
+++ b/tests/integration/s3api/test_abort_multipart_upload.py
@@ -1,0 +1,34 @@
+"""Integration test for S3 AbortMultipartUpload."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import httpx
+
+
+class TestAbortMultipartUpload:
+    async def test_abort_multipart_upload(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 204
+        expected_bucket = "test-bucket"
+        expected_key = "test-key"
+
+        create_resp = await client.post(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploads": ""},
+        )
+        root = ET.fromstring(create_resp.text)
+        ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+        upload_id = root.findtext("s3:UploadId", default="", namespaces=ns)
+        if not upload_id:
+            upload_id = root.findtext("UploadId", default="")
+
+        # Act
+        resp = await client.delete(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploadId": upload_id},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/s3api/test_complete_multipart_upload.py
+++ b/tests/integration/s3api/test_complete_multipart_upload.py
@@ -1,0 +1,53 @@
+"""Integration test for S3 CompleteMultipartUpload."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import httpx
+
+
+class TestCompleteMultipartUpload:
+    async def test_complete_multipart_upload(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_bucket = "test-bucket"
+        expected_key = "test-key"
+        expected_part_data = b"part-data"
+
+        create_resp = await client.post(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploads": ""},
+        )
+        root = ET.fromstring(create_resp.text)
+        ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+        upload_id = root.findtext("s3:UploadId", default="", namespaces=ns)
+        if not upload_id:
+            upload_id = root.findtext("UploadId", default="")
+
+        part_resp = await client.put(
+            f"/{expected_bucket}/{expected_key}",
+            params={"partNumber": "1", "uploadId": upload_id},
+            content=expected_part_data,
+        )
+        etag = part_resp.headers.get("ETag", "")
+
+        complete_body = (
+            "<CompleteMultipartUpload>"
+            "<Part>"
+            "<PartNumber>1</PartNumber>"
+            f"<ETag>{etag}</ETag>"
+            "</Part>"
+            "</CompleteMultipartUpload>"
+        )
+
+        # Act
+        resp = await client.post(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploadId": upload_id},
+            content=complete_body.encode(),
+            headers={"Content-Type": "application/xml"},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/s3api/test_create_multipart_upload.py
+++ b/tests/integration/s3api/test_create_multipart_upload.py
@@ -1,0 +1,22 @@
+"""Integration test for S3 CreateMultipartUpload."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestCreateMultipartUpload:
+    async def test_create_multipart_upload(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_bucket = "test-bucket"
+        expected_key = "test-key"
+
+        # Act
+        resp = await client.post(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploads": ""},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/s3api/test_upload_part.py
+++ b/tests/integration/s3api/test_upload_part.py
@@ -1,0 +1,36 @@
+"""Integration test for S3 UploadPart."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import httpx
+
+
+class TestUploadPart:
+    async def test_upload_part(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_bucket = "test-bucket"
+        expected_key = "test-key"
+        expected_part_data = b"part-data"
+
+        create_resp = await client.post(
+            f"/{expected_bucket}/{expected_key}",
+            params={"uploads": ""},
+        )
+        root = ET.fromstring(create_resp.text)
+        ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+        upload_id = root.findtext("s3:UploadId", default="", namespaces=ns)
+        if not upload_id:
+            upload_id = root.findtext("UploadId", default="")
+
+        # Act
+        resp = await client.put(
+            f"/{expected_bucket}/{expected_key}",
+            params={"partNumber": "1", "uploadId": upload_id},
+            content=expected_part_data,
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_get_resource_policy.py
+++ b/tests/integration/secretsmanager/test_get_resource_policy.py
@@ -1,0 +1,28 @@
+"""Integration test for Secrets Manager GetResourcePolicy."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetResourcePolicy:
+    async def test_get_resource_policy(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/policy-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.GetResourcePolicy"},
+            json={"SecretId": secret_name},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_list_secret_version_ids.py
+++ b/tests/integration/secretsmanager/test_list_secret_version_ids.py
@@ -1,0 +1,28 @@
+"""Integration test for Secrets Manager ListSecretVersionIds."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListSecretVersionIds:
+    async def test_list_secret_version_ids(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/version-ids-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.ListSecretVersionIds"},
+            json={"SecretId": secret_name},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_restore_secret.py
+++ b/tests/integration/secretsmanager/test_restore_secret.py
@@ -1,0 +1,33 @@
+"""Integration test for Secrets Manager RestoreSecret."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestRestoreSecret:
+    async def test_restore_secret(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/restore-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "value"},
+        )
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.DeleteSecret"},
+            json={"SecretId": secret_name},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.RestoreSecret"},
+            json={"SecretId": secret_name},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_tag_resource.py
+++ b/tests/integration/secretsmanager/test_tag_resource.py
@@ -1,0 +1,31 @@
+"""Integration test for Secrets Manager TagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTagResource:
+    async def test_tag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/tag-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.TagResource"},
+            json={
+                "SecretId": secret_name,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_untag_resource.py
+++ b/tests/integration/secretsmanager/test_untag_resource.py
@@ -1,0 +1,39 @@
+"""Integration test for Secrets Manager UntagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUntagResource:
+    async def test_untag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/untag-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "value"},
+        )
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.TagResource"},
+            json={
+                "SecretId": secret_name,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.UntagResource"},
+            json={
+                "SecretId": secret_name,
+                "TagKeys": ["env"],
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/secretsmanager/test_update_secret.py
+++ b/tests/integration/secretsmanager/test_update_secret.py
@@ -1,0 +1,28 @@
+"""Integration test for Secrets Manager UpdateSecret."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUpdateSecret:
+    async def test_update_secret(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        secret_name = "app/update-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.CreateSecret"},
+            json={"Name": secret_name, "SecretString": "old-value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "secretsmanager.UpdateSecret"},
+            json={"SecretId": secret_name, "SecretString": "new-value"},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/sns/test_confirm_subscription.py
+++ b/tests/integration/sns/test_confirm_subscription.py
@@ -1,0 +1,25 @@
+"""Integration test for SNS ConfirmSubscription."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestConfirmSubscription:
+    async def test_confirm_subscription(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ConfirmSubscription",
+                "TopicArn": expected_topic_arn,
+                "Token": "dummy-token",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_get_subscription_attributes.py
+++ b/tests/integration/sns/test_get_subscription_attributes.py
@@ -1,0 +1,41 @@
+"""Integration test for SNS GetSubscriptionAttributes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetSubscriptionAttributes:
+    async def test_get_subscription_attributes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+        expected_endpoint = "arn:aws:sqs:us-east-1:123456789012:get-sub-attrs-queue"
+
+        sub_resp = await client.post(
+            "/",
+            data={
+                "Action": "Subscribe",
+                "TopicArn": expected_topic_arn,
+                "Protocol": "sqs",
+                "Endpoint": expected_endpoint,
+            },
+        )
+        assert "<SubscriptionArn>" in sub_resp.text
+
+        text = sub_resp.text
+        start = text.index("<SubscriptionArn>") + len("<SubscriptionArn>")
+        end = text.index("</SubscriptionArn>")
+        subscription_arn = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "GetSubscriptionAttributes",
+                "SubscriptionArn": subscription_arn,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_get_topic_attributes.py
+++ b/tests/integration/sns/test_get_topic_attributes.py
@@ -1,0 +1,24 @@
+"""Integration test for SNS GetTopicAttributes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetTopicAttributes:
+    async def test_get_topic_attributes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "GetTopicAttributes",
+                "TopicArn": expected_topic_arn,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_list_subscriptions_by_topic.py
+++ b/tests/integration/sns/test_list_subscriptions_by_topic.py
@@ -1,0 +1,24 @@
+"""Integration test for SNS ListSubscriptionsByTopic."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListSubscriptionsByTopic:
+    async def test_list_subscriptions_by_topic(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ListSubscriptionsByTopic",
+                "TopicArn": expected_topic_arn,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_list_tags_for_resource.py
+++ b/tests/integration/sns/test_list_tags_for_resource.py
@@ -1,0 +1,24 @@
+"""Integration test for SNS ListTagsForResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListTagsForResource:
+    async def test_list_tags_for_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ListTagsForResource",
+                "ResourceArn": expected_resource_arn,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_set_subscription_attributes.py
+++ b/tests/integration/sns/test_set_subscription_attributes.py
@@ -1,0 +1,43 @@
+"""Integration test for SNS SetSubscriptionAttributes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestSetSubscriptionAttributes:
+    async def test_set_subscription_attributes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+        expected_endpoint = "arn:aws:sqs:us-east-1:123456789012:set-sub-attrs-queue"
+
+        sub_resp = await client.post(
+            "/",
+            data={
+                "Action": "Subscribe",
+                "TopicArn": expected_topic_arn,
+                "Protocol": "sqs",
+                "Endpoint": expected_endpoint,
+            },
+        )
+        assert "<SubscriptionArn>" in sub_resp.text
+
+        text = sub_resp.text
+        start = text.index("<SubscriptionArn>") + len("<SubscriptionArn>")
+        end = text.index("</SubscriptionArn>")
+        subscription_arn = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "SetSubscriptionAttributes",
+                "SubscriptionArn": subscription_arn,
+                "AttributeName": "RawMessageDelivery",
+                "AttributeValue": "true",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_set_topic_attributes.py
+++ b/tests/integration/sns/test_set_topic_attributes.py
@@ -1,0 +1,26 @@
+"""Integration test for SNS SetTopicAttributes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestSetTopicAttributes:
+    async def test_set_topic_attributes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "SetTopicAttributes",
+                "TopicArn": expected_topic_arn,
+                "AttributeName": "DisplayName",
+                "AttributeValue": "Integration Test Topic",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_tag_resource.py
+++ b/tests/integration/sns/test_tag_resource.py
@@ -1,0 +1,26 @@
+"""Integration test for SNS TagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTagResource:
+    async def test_tag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "TagResource",
+                "ResourceArn": expected_resource_arn,
+                "Tags.member.1.Key": "env",
+                "Tags.member.1.Value": "test",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_unsubscribe.py
+++ b/tests/integration/sns/test_unsubscribe.py
@@ -1,0 +1,41 @@
+"""Integration test for SNS Unsubscribe."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUnsubscribe:
+    async def test_unsubscribe(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_topic_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+        expected_endpoint = "arn:aws:sqs:us-east-1:123456789012:unsub-queue"
+
+        sub_resp = await client.post(
+            "/",
+            data={
+                "Action": "Subscribe",
+                "TopicArn": expected_topic_arn,
+                "Protocol": "sqs",
+                "Endpoint": expected_endpoint,
+            },
+        )
+        assert "<SubscriptionArn>" in sub_resp.text
+
+        text = sub_resp.text
+        start = text.index("<SubscriptionArn>") + len("<SubscriptionArn>")
+        end = text.index("</SubscriptionArn>")
+        subscription_arn = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "Unsubscribe",
+                "SubscriptionArn": subscription_arn,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sns/test_untag_resource.py
+++ b/tests/integration/sns/test_untag_resource.py
@@ -1,0 +1,25 @@
+"""Integration test for SNS UntagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUntagResource:
+    async def test_untag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_resource_arn = "arn:aws:sns:us-east-1:123456789012:test-topic"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "UntagResource",
+                "ResourceArn": expected_resource_arn,
+                "TagKeys.member.1": "env",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_change_message_visibility.py
+++ b/tests/integration/sqs/test_change_message_visibility.py
@@ -1,0 +1,50 @@
+"""Integration test for SQS ChangeMessageVisibility."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestChangeMessageVisibility:
+    async def test_change_message_visibility(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        await client.post(
+            "/",
+            data={
+                "Action": "SendMessage",
+                "QueueUrl": queue_url,
+                "MessageBody": "vis-test",
+            },
+        )
+
+        recv_resp = await client.post(
+            "/",
+            data={
+                "Action": "ReceiveMessage",
+                "QueueUrl": queue_url,
+                "MaxNumberOfMessages": "1",
+            },
+        )
+        assert "<ReceiptHandle>" in recv_resp.text
+
+        text = recv_resp.text
+        start = text.index("<ReceiptHandle>") + len("<ReceiptHandle>")
+        end = text.index("</ReceiptHandle>")
+        receipt_handle = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ChangeMessageVisibility",
+                "QueueUrl": queue_url,
+                "ReceiptHandle": receipt_handle,
+                "VisibilityTimeout": "60",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_change_message_visibility_batch.py
+++ b/tests/integration/sqs/test_change_message_visibility_batch.py
@@ -1,0 +1,51 @@
+"""Integration test for SQS ChangeMessageVisibilityBatch."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestChangeMessageVisibilityBatch:
+    async def test_change_message_visibility_batch(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        await client.post(
+            "/",
+            data={
+                "Action": "SendMessage",
+                "QueueUrl": queue_url,
+                "MessageBody": "vis-batch-test",
+            },
+        )
+
+        recv_resp = await client.post(
+            "/",
+            data={
+                "Action": "ReceiveMessage",
+                "QueueUrl": queue_url,
+                "MaxNumberOfMessages": "1",
+            },
+        )
+        assert "<ReceiptHandle>" in recv_resp.text
+
+        text = recv_resp.text
+        start = text.index("<ReceiptHandle>") + len("<ReceiptHandle>")
+        end = text.index("</ReceiptHandle>")
+        receipt_handle = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ChangeMessageVisibilityBatch",
+                "QueueUrl": queue_url,
+                "ChangeMessageVisibilityBatchRequestEntry.1.Id": "msg1",
+                "ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle": receipt_handle,
+                "ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout": "60",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_delete_message_batch.py
+++ b/tests/integration/sqs/test_delete_message_batch.py
@@ -1,0 +1,50 @@
+"""Integration test for SQS DeleteMessageBatch."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteMessageBatch:
+    async def test_delete_message_batch(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        await client.post(
+            "/",
+            data={
+                "Action": "SendMessage",
+                "QueueUrl": queue_url,
+                "MessageBody": "batch-delete-me",
+            },
+        )
+
+        recv_resp = await client.post(
+            "/",
+            data={
+                "Action": "ReceiveMessage",
+                "QueueUrl": queue_url,
+                "MaxNumberOfMessages": "1",
+            },
+        )
+        assert "<ReceiptHandle>" in recv_resp.text
+
+        text = recv_resp.text
+        start = text.index("<ReceiptHandle>") + len("<ReceiptHandle>")
+        end = text.index("</ReceiptHandle>")
+        receipt_handle = text[start:end]
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "DeleteMessageBatch",
+                "QueueUrl": queue_url,
+                "DeleteMessageBatchRequestEntry.1.Id": "msg1",
+                "DeleteMessageBatchRequestEntry.1.ReceiptHandle": receipt_handle,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_get_queue_url.py
+++ b/tests/integration/sqs/test_get_queue_url.py
@@ -1,0 +1,23 @@
+"""Integration test for SQS GetQueueUrl."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetQueueUrl:
+    async def test_get_queue_url(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        expected_queue_name = "test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={"Action": "GetQueueUrl", "QueueName": expected_queue_name},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        assert "<QueueUrl>" in resp.text
+        assert expected_queue_name in resp.text

--- a/tests/integration/sqs/test_list_dead_letter_source_queues.py
+++ b/tests/integration/sqs/test_list_dead_letter_source_queues.py
@@ -1,0 +1,24 @@
+"""Integration test for SQS ListDeadLetterSourceQueues."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListDeadLetterSourceQueues:
+    async def test_list_dead_letter_source_queues(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ListDeadLetterSourceQueues",
+                "QueueUrl": queue_url,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_list_queue_tags.py
+++ b/tests/integration/sqs/test_list_queue_tags.py
@@ -1,0 +1,24 @@
+"""Integration test for SQS ListQueueTags."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListQueueTags:
+    async def test_list_queue_tags(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "ListQueueTags",
+                "QueueUrl": queue_url,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_send_message_batch.py
+++ b/tests/integration/sqs/test_send_message_batch.py
@@ -1,0 +1,26 @@
+"""Integration test for SQS SendMessageBatch."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestSendMessageBatch:
+    async def test_send_message_batch(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "SendMessageBatch",
+                "QueueUrl": queue_url,
+                "SendMessageBatchRequestEntry.1.Id": "msg1",
+                "SendMessageBatchRequestEntry.1.MessageBody": "hello batch",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_set_queue_attributes.py
+++ b/tests/integration/sqs/test_set_queue_attributes.py
@@ -1,0 +1,26 @@
+"""Integration test for SQS SetQueueAttributes."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestSetQueueAttributes:
+    async def test_set_queue_attributes(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "SetQueueAttributes",
+                "QueueUrl": queue_url,
+                "Attribute.1.Name": "VisibilityTimeout",
+                "Attribute.1.Value": "30",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_tag_queue.py
+++ b/tests/integration/sqs/test_tag_queue.py
@@ -1,0 +1,26 @@
+"""Integration test for SQS TagQueue."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestTagQueue:
+    async def test_tag_queue(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "TagQueue",
+                "QueueUrl": queue_url,
+                "Tag.1.Key": "env",
+                "Tag.1.Value": "test",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/sqs/test_untag_queue.py
+++ b/tests/integration/sqs/test_untag_queue.py
@@ -1,0 +1,25 @@
+"""Integration test for SQS UntagQueue."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestUntagQueue:
+    async def test_untag_queue(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        queue_url = "http://testserver/000000000000/test-queue"
+
+        # Act
+        resp = await client.post(
+            "/",
+            data={
+                "Action": "UntagQueue",
+                "QueueUrl": queue_url,
+                "TagKey.1": "env",
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/ssm/test_add_tags_to_resource.py
+++ b/tests/integration/ssm/test_add_tags_to_resource.py
@@ -1,0 +1,32 @@
+"""Integration test for SSM AddTagsToResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestAddTagsToResource:
+    async def test_add_tags_to_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        param_name = "/app/tag-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name, "Value": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.AddTagsToResource"},
+            json={
+                "ResourceType": "Parameter",
+                "ResourceId": param_name,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/ssm/test_delete_parameters.py
+++ b/tests/integration/ssm/test_delete_parameters.py
@@ -1,0 +1,28 @@
+"""Integration test for SSM DeleteParameters."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestDeleteParameters:
+    async def test_delete_parameters(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        param_name = "/app/to-delete-batch"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name, "Value": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.DeleteParameters"},
+            json={"Names": [param_name]},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/ssm/test_get_parameters.py
+++ b/tests/integration/ssm/test_get_parameters.py
@@ -1,0 +1,36 @@
+"""Integration test for SSM GetParameters."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestGetParameters:
+    async def test_get_parameters(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        param_name_1 = "/app/param1"
+        param_name_2 = "/app/param2"
+        expected_value_1 = "value1"
+        expected_value_2 = "value2"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name_1, "Value": expected_value_1},
+        )
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name_2, "Value": expected_value_2},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.GetParameters"},
+            json={"Names": [param_name_1, param_name_2]},
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/ssm/test_list_tags_for_resource.py
+++ b/tests/integration/ssm/test_list_tags_for_resource.py
@@ -1,0 +1,31 @@
+"""Integration test for SSM ListTagsForResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestListTagsForResource:
+    async def test_list_tags_for_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        param_name = "/app/list-tags-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name, "Value": "value"},
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.ListTagsForResource"},
+            json={
+                "ResourceType": "Parameter",
+                "ResourceId": param_name,
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/ssm/test_remove_tags_from_resource.py
+++ b/tests/integration/ssm/test_remove_tags_from_resource.py
@@ -1,0 +1,41 @@
+"""Integration test for SSM RemoveTagsFromResource."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class TestRemoveTagsFromResource:
+    async def test_remove_tags_from_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        param_name = "/app/untag-target"
+
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.PutParameter"},
+            json={"Name": param_name, "Value": "value"},
+        )
+        await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.AddTagsToResource"},
+            json={
+                "ResourceType": "Parameter",
+                "ResourceId": param_name,
+                "Tags": [{"Key": "env", "Value": "test"}],
+            },
+        )
+
+        # Act
+        response = await client.post(
+            "/",
+            headers={"X-Amz-Target": "AmazonSSM.RemoveTagsFromResource"},
+            json={
+                "ResourceType": "Parameter",
+                "ResourceId": param_name,
+                "TagKeys": ["env"],
+            },
+        )
+
+        # Assert
+        assert response.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_get_execution_history.py
+++ b/tests/integration/stepfunctions/test_get_execution_history.py
@@ -1,0 +1,30 @@
+"""Integration test for Step Functions GetExecutionHistory."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestGetExecutionHistory:
+    async def test_get_execution_history(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        start_resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.StartExecution"},
+            json={"stateMachineArn": _SM_ARN},
+        )
+        expected_execution_arn = start_resp.json()["executionArn"]
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.GetExecutionHistory"},
+            json={"executionArn": expected_execution_arn},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_list_state_machine_versions.py
+++ b/tests/integration/stepfunctions/test_list_state_machine_versions.py
@@ -1,0 +1,23 @@
+"""Integration test for Step Functions ListStateMachineVersions."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestListStateMachineVersions:
+    async def test_list_state_machine_versions(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.ListStateMachineVersions"},
+            json={"stateMachineArn": _SM_ARN},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_list_tags_for_resource.py
+++ b/tests/integration/stepfunctions/test_list_tags_for_resource.py
@@ -1,0 +1,23 @@
+"""Integration test for Step Functions ListTagsForResource."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestListTagsForResource:
+    async def test_list_tags_for_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.ListTagsForResource"},
+            json={"resourceArn": _SM_ARN},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_start_sync_execution.py
+++ b/tests/integration/stepfunctions/test_start_sync_execution.py
@@ -1,0 +1,28 @@
+"""Integration test for Step Functions StartSyncExecution."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestStartSyncExecution:
+    async def test_start_sync_execution(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.StartSyncExecution"},
+            json={
+                "stateMachineArn": _SM_ARN,
+                "input": json.dumps({}),
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_stop_execution.py
+++ b/tests/integration/stepfunctions/test_stop_execution.py
@@ -1,0 +1,30 @@
+"""Integration test for Step Functions StopExecution."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestStopExecution:
+    async def test_stop_execution(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        start_resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.StartExecution"},
+            json={"stateMachineArn": _SM_ARN},
+        )
+        expected_execution_arn = start_resp.json()["executionArn"]
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.StopExecution"},
+            json={"executionArn": expected_execution_arn},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_tag_resource.py
+++ b/tests/integration/stepfunctions/test_tag_resource.py
@@ -1,0 +1,26 @@
+"""Integration test for Step Functions TagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestTagResource:
+    async def test_tag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.TagResource"},
+            json={
+                "resourceArn": _SM_ARN,
+                "tags": [{"key": "env", "value": "test"}],
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_untag_resource.py
+++ b/tests/integration/stepfunctions/test_untag_resource.py
@@ -1,0 +1,26 @@
+"""Integration test for Step Functions UntagResource."""
+
+from __future__ import annotations
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestUntagResource:
+    async def test_untag_resource(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.UntagResource"},
+            json={
+                "resourceArn": _SM_ARN,
+                "tagKeys": ["env"],
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_update_state_machine.py
+++ b/tests/integration/stepfunctions/test_update_state_machine.py
@@ -1,0 +1,31 @@
+"""Integration test for Step Functions UpdateStateMachine."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+_SM_ARN = "arn:aws:states:us-east-1:000000000000:stateMachine:PassMachine"
+
+
+class TestUpdateStateMachine:
+    async def test_update_state_machine(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        updated_definition = json.dumps(
+            {"StartAt": "PassUpdated", "States": {"PassUpdated": {"Type": "Pass", "End": True}}}
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.UpdateStateMachine"},
+            json={
+                "stateMachineArn": _SM_ARN,
+                "definition": updated_definition,
+            },
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/integration/stepfunctions/test_validate_state_machine_definition.py
+++ b/tests/integration/stepfunctions/test_validate_state_machine_definition.py
@@ -1,0 +1,26 @@
+"""Integration test for Step Functions ValidateStateMachineDefinition."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class TestValidateStateMachineDefinition:
+    async def test_validate_state_machine_definition(self, client: httpx.AsyncClient):
+        # Arrange
+        expected_status_code = 200
+        definition = json.dumps(
+            {"StartAt": "Pass", "States": {"Pass": {"Type": "Pass", "End": True}}}
+        )
+
+        # Act
+        resp = await client.post(
+            "/",
+            headers={"x-amz-target": "AWSStepFunctions.ValidateStateMachineDefinition"},
+            json={"definition": definition},
+        )
+
+        # Assert
+        assert resp.status_code == expected_status_code

--- a/tests/unit/providers/test_cognito_provider_change_password.py
+++ b/tests/unit/providers/test_cognito_provider_change_password.py
@@ -1,0 +1,77 @@
+"""Tests for CognitoProvider change password via access token."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lws.providers.cognito.provider import CognitoProvider
+from lws.providers.cognito.user_store import (
+    NotAuthorizedException,
+    PasswordPolicy,
+    UserPoolConfig,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def provider(tmp_path: Path):
+    """Create, start, yield, and stop a CognitoProvider."""
+    config = _default_config()
+    p = CognitoProvider(data_dir=tmp_path, config=config)
+    await p.start()
+    yield p
+    await p.stop()
+
+
+class TestCognitoProviderChangePassword:
+    """Change password via access token."""
+
+    async def test_change_password_success(self, provider: CognitoProvider) -> None:
+        # Arrange
+        username = "alice"
+        old_password = "Password1A"
+        new_password = "NewPass1B"
+        await provider.sign_up(username, old_password)
+        auth_result = await provider.initiate_auth("USER_PASSWORD_AUTH", username, old_password)
+        access_token = auth_result["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        await provider.change_password(access_token, old_password, new_password)
+
+        # Assert
+        result = await provider.initiate_auth("USER_PASSWORD_AUTH", username, new_password)
+        assert "AuthenticationResult" in result
+
+    async def test_change_password_wrong_old_raises(self, provider: CognitoProvider) -> None:
+        # Arrange
+        username = "bob"
+        password = "Password1A"
+        await provider.sign_up(username, password)
+        auth_result = await provider.initiate_auth("USER_PASSWORD_AUTH", username, password)
+        access_token = auth_result["AuthenticationResult"]["AccessToken"]
+
+        # Act
+        # Assert
+        with pytest.raises(NotAuthorizedException):
+            await provider.change_password(access_token, "WrongPass1", "NewPass1B")

--- a/tests/unit/providers/test_cognito_provider_forgot_password.py
+++ b/tests/unit/providers/test_cognito_provider_forgot_password.py
@@ -1,0 +1,77 @@
+"""Tests for CognitoProvider forgot password flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lws.providers.cognito.provider import CognitoProvider
+from lws.providers.cognito.user_store import (
+    PasswordPolicy,
+    UserPoolConfig,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def provider(tmp_path: Path):
+    """Create, start, yield, and stop a CognitoProvider."""
+    config = _default_config()
+    p = CognitoProvider(data_dir=tmp_path, config=config)
+    await p.start()
+    yield p
+    await p.stop()
+
+
+class TestCognitoProviderForgotPassword:
+    """Forgot password and confirm forgot password flow."""
+
+    async def test_forgot_password_returns_code_delivery(self, provider: CognitoProvider) -> None:
+        # Arrange
+        username = "alice"
+        password = "Password1A"
+        await provider.sign_up(username, password)
+
+        # Act
+        result = await provider.forgot_password("test-client-id", username)
+
+        # Assert
+        expected_medium = "EMAIL"
+        actual_medium = result["CodeDeliveryDetails"]["DeliveryMedium"]
+        assert actual_medium == expected_medium
+
+    async def test_forgot_then_confirm_resets_password(self, provider: CognitoProvider) -> None:
+        # Arrange
+        username = "bob"
+        old_password = "Password1A"
+        new_password = "NewPass1B"
+        await provider.sign_up(username, old_password)
+        await provider.forgot_password("test-client-id", username)
+        code = await provider.store.create_password_reset_code(username)
+
+        # Act
+        await provider.confirm_forgot_password("test-client-id", username, code, new_password)
+
+        # Assert
+        result = await provider.initiate_auth("USER_PASSWORD_AUTH", username, new_password)
+        assert "AuthenticationResult" in result

--- a/tests/unit/providers/test_cognito_provider_global_sign_out.py
+++ b/tests/unit/providers/test_cognito_provider_global_sign_out.py
@@ -1,0 +1,64 @@
+"""Tests for CognitoProvider global sign out."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lws.providers.cognito.provider import CognitoProvider
+from lws.providers.cognito.user_store import (
+    NotAuthorizedException,
+    PasswordPolicy,
+    UserPoolConfig,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def provider(tmp_path: Path):
+    """Create, start, yield, and stop a CognitoProvider."""
+    config = _default_config()
+    p = CognitoProvider(data_dir=tmp_path, config=config)
+    await p.start()
+    yield p
+    await p.stop()
+
+
+class TestCognitoProviderGlobalSignOut:
+    """Global sign out revokes refresh tokens."""
+
+    async def test_global_sign_out_revokes_refresh_tokens(self, provider: CognitoProvider) -> None:
+        # Arrange
+        username = "alice"
+        password = "Password1A"
+        await provider.sign_up(username, password)
+        auth_result = await provider.initiate_auth("USER_PASSWORD_AUTH", username, password)
+        access_token = auth_result["AuthenticationResult"]["AccessToken"]
+        refresh_token = auth_result["AuthenticationResult"]["RefreshToken"]
+
+        # Act
+        await provider.global_sign_out(access_token)
+
+        # Assert
+        with pytest.raises(NotAuthorizedException):
+            await provider.refresh_tokens(refresh_token)

--- a/tests/unit/providers/test_cognito_user_store_change_password.py
+++ b/tests/unit/providers/test_cognito_user_store_change_password.py
@@ -1,0 +1,75 @@
+"""Tests for UserStore change password operation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lws.providers.cognito.user_store import (
+    NotAuthorizedException,
+    PasswordPolicy,
+    UserPoolConfig,
+    UserStore,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    """Create, start, yield, and stop a UserStore."""
+    config = _default_config()
+    s = UserStore(tmp_path, config)
+    await s.start()
+    yield s
+    await s.stop()
+
+
+class TestUserStoreChangePassword:
+    """Change password success and wrong old password tests."""
+
+    async def test_change_password_success(self, store: UserStore) -> None:
+        # Arrange
+        username = "alice"
+        old_password = "Password1A"
+        new_password = "NewPass1B"
+        await store.sign_up(username, old_password)
+
+        # Act
+        await store.change_password(username, old_password, new_password)
+
+        # Assert
+        user_info = await store.authenticate(username, new_password)
+        actual_username = user_info["username"]
+        expected_username = username
+        assert actual_username == expected_username
+
+    async def test_change_password_wrong_old_password_raises(self, store: UserStore) -> None:
+        # Arrange
+        username = "bob"
+        password = "Password1A"
+        await store.sign_up(username, password)
+
+        # Act
+        # Assert
+        with pytest.raises(NotAuthorizedException):
+            await store.change_password(username, "WrongPass1", "NewPass1B")

--- a/tests/unit/providers/test_cognito_user_store_password_reset.py
+++ b/tests/unit/providers/test_cognito_user_store_password_reset.py
@@ -1,0 +1,101 @@
+"""Tests for UserStore password reset code operations."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from lws.providers.cognito.user_store import (
+    CodeMismatchException,
+    ExpiredCodeException,
+    PasswordPolicy,
+    UserNotFoundException,
+    UserPoolConfig,
+    UserStore,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    """Create, start, yield, and stop a UserStore."""
+    config = _default_config()
+    s = UserStore(tmp_path, config)
+    await s.start()
+    yield s
+    await s.stop()
+
+
+class TestUserStorePasswordReset:
+    """Password reset code create, confirm, expired, and wrong code tests."""
+
+    async def test_create_and_confirm_reset_code(self, store: UserStore) -> None:
+        # Arrange
+        username = "alice"
+        password = "Password1A"
+        new_password = "NewPass1B"
+        await store.sign_up(username, password)
+
+        # Act
+        code = await store.create_password_reset_code(username)
+        await store.confirm_password_reset(username, code, new_password)
+
+        # Assert
+        user_info = await store.authenticate(username, new_password)
+        actual_username = user_info["username"]
+        expected_username = username
+        assert actual_username == expected_username
+
+    async def test_expired_code_raises(self, store: UserStore) -> None:
+        # Arrange
+        username = "bob"
+        password = "Password1A"
+        await store.sign_up(username, password)
+        code = await store.create_password_reset_code(username)
+
+        # Act
+        # Assert
+        with patch("lws.providers.cognito.user_store.time") as mock_time:
+            mock_time.time.return_value = time.time() + 600
+            with pytest.raises(ExpiredCodeException):
+                await store.confirm_password_reset(username, code, "NewPass1B")
+
+    async def test_wrong_code_raises(self, store: UserStore) -> None:
+        # Arrange
+        username = "carol"
+        password = "Password1A"
+        await store.sign_up(username, password)
+        await store.create_password_reset_code(username)
+
+        # Act
+        # Assert
+        with pytest.raises(CodeMismatchException):
+            await store.confirm_password_reset(username, "000000", "NewPass1B")
+
+    async def test_create_code_for_nonexistent_user_raises(self, store: UserStore) -> None:
+        # Act
+        # Assert
+        with pytest.raises(UserNotFoundException):
+            await store.create_password_reset_code("nobody")

--- a/tests/unit/providers/test_cognito_user_store_revoke_tokens.py
+++ b/tests/unit/providers/test_cognito_user_store_revoke_tokens.py
@@ -1,0 +1,77 @@
+"""Tests for UserStore revoke refresh tokens operation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lws.providers.cognito.user_store import (
+    PasswordPolicy,
+    UserPoolConfig,
+    UserStore,
+)
+
+
+def _default_config(**overrides: Any) -> UserPoolConfig:
+    """Create a default UserPoolConfig with optional overrides."""
+    kwargs: dict[str, Any] = {
+        "user_pool_id": "us-east-1_TestPool",
+        "user_pool_name": "test-pool",
+        "password_policy": PasswordPolicy(
+            minimum_length=8,
+            require_lowercase=True,
+            require_uppercase=True,
+            require_digits=True,
+            require_symbols=False,
+        ),
+        "auto_confirm": True,
+        "client_id": "test-client-id",
+    }
+    kwargs.update(overrides)
+    return UserPoolConfig(**kwargs)
+
+
+@pytest.fixture
+async def store(tmp_path: Path):
+    """Create, start, yield, and stop a UserStore."""
+    config = _default_config()
+    s = UserStore(tmp_path, config)
+    await s.start()
+    yield s
+    await s.stop()
+
+
+class TestUserStoreRevokeTokens:
+    """Revoke refresh tokens clears stored tokens."""
+
+    async def test_revoke_clears_all_tokens(self, store: UserStore) -> None:
+        # Arrange
+        username = "alice"
+        await store.store_refresh_token("token1", username, 1000.0)
+        await store.store_refresh_token("token2", username, 1001.0)
+
+        # Act
+        await store.revoke_refresh_tokens(username)
+
+        # Assert
+        actual_token1 = await store.get_refresh_token_username("token1")
+        actual_token2 = await store.get_refresh_token_username("token2")
+        assert actual_token1 is None
+        assert actual_token2 is None
+
+    async def test_revoke_does_not_affect_other_users(self, store: UserStore) -> None:
+        # Arrange
+        await store.store_refresh_token("alice-token", "alice", 1000.0)
+        await store.store_refresh_token("bob-token", "bob", 1001.0)
+
+        # Act
+        await store.revoke_refresh_tokens("alice")
+
+        # Assert
+        actual_alice = await store.get_refresh_token_username("alice-token")
+        actual_bob = await store.get_refresh_token_username("bob-token")
+        assert actual_alice is None
+        expected_bob = "bob"
+        assert actual_bob == expected_bob

--- a/tests/unit/providers/test_dynamodb_routes_transact_condition_check.py
+++ b/tests/unit/providers/test_dynamodb_routes_transact_condition_check.py
@@ -1,0 +1,234 @@
+"""Tests for DynamoDB TransactWriteItems ConditionCheck evaluation."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from lws.interfaces.key_value_store import KeyAttribute, KeySchema, TableConfig
+from lws.providers.dynamodb.provider import SqliteDynamoProvider
+from lws.providers.dynamodb.routes import create_dynamodb_app
+
+TARGET_PREFIX = "DynamoDB_20120810."
+
+
+def _target(operation: str) -> dict[str, str]:
+    return {"X-Amz-Target": f"{TARGET_PREFIX}{operation}"}
+
+
+_TABLE_CONFIG = TableConfig(
+    table_name="TestTable",
+    key_schema=KeySchema(
+        partition_key=KeyAttribute(name="pk", type="S"),
+    ),
+)
+
+
+@pytest.fixture()
+async def provider(tmp_path):
+    p = SqliteDynamoProvider(data_dir=tmp_path, tables=[_TABLE_CONFIG])
+    await p.start()
+    yield p
+    await p.stop()
+
+
+@pytest.fixture()
+def client(provider: SqliteDynamoProvider) -> httpx.AsyncClient:
+    app = create_dynamodb_app(provider)
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+class TestTransactConditionCheck:
+    @pytest.mark.asyncio
+    async def test_condition_check_passes_writes_execute(
+        self, client: httpx.AsyncClient, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        table_name = "TestTable"
+        await provider.put_item(table_name, {"pk": {"S": "existing"}, "status": {"S": "active"}})
+        payload = {
+            "TransactItems": [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "existing"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {"pk": {"S": "new-item"}, "data": {"S": "hello"}},
+                    }
+                },
+            ]
+        }
+        expected_status_code = 200
+        expected_data = {"S": "hello"}
+
+        # Act
+        resp = await client.post("/", json=payload, headers=_target("TransactWriteItems"))
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        item = await provider.get_item(table_name, {"pk": {"S": "new-item"}})
+        actual_data = item["data"]
+        assert actual_data == expected_data
+
+    @pytest.mark.asyncio
+    async def test_condition_check_fails_no_writes_execute(
+        self, client: httpx.AsyncClient, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        table_name = "TestTable"
+        payload = {
+            "TransactItems": [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "nonexistent"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {"pk": {"S": "should-not-exist"}, "data": {"S": "nope"}},
+                    }
+                },
+            ]
+        }
+        expected_status_code = 400
+        expected_error_type = "com.amazonaws.dynamodb.v20120810#TransactionCanceledException"
+
+        # Act
+        resp = await client.post("/", json=payload, headers=_target("TransactWriteItems"))
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        body = resp.json()
+        actual_error_type = body["__type"]
+        assert actual_error_type == expected_error_type
+        assert len(body["CancellationReasons"]) == 2
+        actual_reason_code = body["CancellationReasons"][0]["Code"]
+        expected_reason_code = "ConditionalCheckFailed"
+        assert actual_reason_code == expected_reason_code
+        item = await provider.get_item(table_name, {"pk": {"S": "should-not-exist"}})
+        assert item is None
+
+    @pytest.mark.asyncio
+    async def test_put_with_condition_expression_fails_transaction_cancelled(
+        self, client: httpx.AsyncClient, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        table_name = "TestTable"
+        payload = {
+            "TransactItems": [
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {"pk": {"S": "item1"}, "data": {"S": "val"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                        "Key": {"pk": {"S": "item1"}},
+                    }
+                },
+            ]
+        }
+        expected_status_code = 400
+
+        # Act
+        resp = await client.post("/", json=payload, headers=_target("TransactWriteItems"))
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        body = resp.json()
+        actual_reason_code = body["CancellationReasons"][0]["Code"]
+        expected_reason_code = "ConditionalCheckFailed"
+        assert actual_reason_code == expected_reason_code
+
+    @pytest.mark.asyncio
+    async def test_multiple_condition_checks_one_fails_all_cancelled(
+        self, client: httpx.AsyncClient, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        table_name = "TestTable"
+        await provider.put_item(table_name, {"pk": {"S": "exists1"}, "val": {"S": "a"}})
+        payload = {
+            "TransactItems": [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "exists1"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "does-not-exist"}},
+                        "ConditionExpression": "attribute_exists(pk)",
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {"pk": {"S": "new"}, "data": {"S": "v"}},
+                    }
+                },
+            ]
+        }
+        expected_status_code = 400
+
+        # Act
+        resp = await client.post("/", json=payload, headers=_target("TransactWriteItems"))
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        body = resp.json()
+        reasons = body["CancellationReasons"]
+        assert len(reasons) == 3
+        actual_first = reasons[0]["Code"]
+        expected_first = "None"
+        assert actual_first == expected_first
+        actual_second = reasons[1]["Code"]
+        expected_second = "ConditionalCheckFailed"
+        assert actual_second == expected_second
+        item = await provider.get_item(table_name, {"pk": {"S": "new"}})
+        assert item is None
+
+    @pytest.mark.asyncio
+    async def test_condition_check_with_expression_attribute_names_and_values(
+        self, client: httpx.AsyncClient, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange
+        table_name = "TestTable"
+        await provider.put_item(table_name, {"pk": {"S": "item1"}, "status": {"S": "active"}})
+        payload = {
+            "TransactItems": [
+                {
+                    "ConditionCheck": {
+                        "TableName": table_name,
+                        "Key": {"pk": {"S": "item1"}},
+                        "ConditionExpression": "#s = :v",
+                        "ExpressionAttributeNames": {"#s": "status"},
+                        "ExpressionAttributeValues": {":v": {"S": "active"}},
+                    }
+                },
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {"pk": {"S": "item2"}, "data": {"S": "ok"}},
+                    }
+                },
+            ]
+        }
+        expected_status_code = 200
+
+        # Act
+        resp = await client.post("/", json=payload, headers=_target("TransactWriteItems"))
+
+        # Assert
+        assert resp.status_code == expected_status_code
+        item = await provider.get_item(table_name, {"pk": {"S": "item2"}})
+        assert item is not None

--- a/tests/unit/providers/test_dynamodb_transact_write_items.py
+++ b/tests/unit/providers/test_dynamodb_transact_write_items.py
@@ -147,6 +147,7 @@ class TestTransactWriteItems:
         self, mock_client: httpx.AsyncClient, mock_store: AsyncMock
     ) -> None:
         # Arrange
+        mock_store.get_item.return_value = {"pk": {"S": "user#3"}}
         payload = {
             "TransactItems": [
                 {

--- a/tests/unit/providers/test_event_source_manager.py
+++ b/tests/unit/providers/test_event_source_manager.py
@@ -1,0 +1,169 @@
+"""Tests for EventSourceManager activation and deactivation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from lws.providers.lambda_runtime.event_source_manager import (
+    EventSourceManager,
+    _extract_function_name,
+    _extract_queue_name,
+    _extract_table_name,
+)
+
+
+class TestEventSourceManager:
+    """EventSourceManager activate/deactivate operations."""
+
+    async def test_activate_sqs_starts_poller(self) -> None:
+        # Arrange
+        queue_provider = AsyncMock()
+        compute = AsyncMock()
+        manager = EventSourceManager(
+            queue_providers={"my-queue": queue_provider},
+            stream_dispatchers={},
+            compute_providers={"my-function": compute},
+        )
+        mapping = {
+            "UUID": "test-uuid-1",
+            "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+            "FunctionArn": "my-function",
+            "BatchSize": 5,
+        }
+
+        # Act
+        with patch(
+            "lws.providers.lambda_runtime.event_source_manager.SqsEventSourcePoller"
+        ) as mock_poller_cls:
+            mock_poller = AsyncMock()
+            mock_poller_cls.return_value = mock_poller
+            await manager.activate(mapping)
+
+        # Assert
+        mock_poller.start.assert_awaited_once()
+
+    async def test_deactivate_stops_poller(self) -> None:
+        # Arrange
+        queue_provider = AsyncMock()
+        compute = AsyncMock()
+        manager = EventSourceManager(
+            queue_providers={"my-queue": queue_provider},
+            stream_dispatchers={},
+            compute_providers={"my-function": compute},
+        )
+        mapping = {
+            "UUID": "test-uuid-2",
+            "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+            "FunctionArn": "my-function",
+        }
+        with patch(
+            "lws.providers.lambda_runtime.event_source_manager.SqsEventSourcePoller"
+        ) as mock_poller_cls:
+            mock_poller = AsyncMock()
+            mock_poller_cls.return_value = mock_poller
+            await manager.activate(mapping)
+
+        # Act
+        await manager.deactivate("test-uuid-2")
+
+        # Assert
+        mock_poller.stop.assert_awaited_once()
+
+    async def test_activate_dynamodb_stream_registers_handler(self) -> None:
+        # Arrange
+        dispatcher = MagicMock()
+        compute = AsyncMock()
+        manager = EventSourceManager(
+            queue_providers={},
+            stream_dispatchers={"my-table": dispatcher},
+            compute_providers={"my-function": compute},
+        )
+        mapping = {
+            "UUID": "test-uuid-3",
+            "EventSourceArn": "arn:aws:dynamodb:us-east-1:000000000000:table/my-table/stream/123",
+            "FunctionArn": "my-function",
+        }
+
+        # Act
+        manager._activate_dynamodb_stream(
+            "test-uuid-3",
+            mapping["EventSourceArn"],
+            "my-function",
+        )
+
+        # Assert
+        dispatcher.register_handler.assert_called_once()
+        actual_table = dispatcher.register_handler.call_args[0][0]
+        expected_table = "my-table"
+        assert actual_table == expected_table
+
+    async def test_stop_all_stops_all_pollers(self) -> None:
+        # Arrange
+        queue_provider = AsyncMock()
+        compute = AsyncMock()
+        manager = EventSourceManager(
+            queue_providers={"q1": queue_provider, "q2": queue_provider},
+            stream_dispatchers={},
+            compute_providers={"f1": compute, "f2": compute},
+        )
+        with patch(
+            "lws.providers.lambda_runtime.event_source_manager.SqsEventSourcePoller"
+        ) as mock_poller_cls:
+            mock_poller1 = AsyncMock()
+            mock_poller2 = AsyncMock()
+            mock_poller_cls.side_effect = [mock_poller1, mock_poller2]
+            await manager.activate(
+                {
+                    "UUID": "u1",
+                    "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:q1",
+                    "FunctionArn": "f1",
+                }
+            )
+            await manager.activate(
+                {
+                    "UUID": "u2",
+                    "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:q2",
+                    "FunctionArn": "f2",
+                }
+            )
+
+        # Act
+        await manager.stop_all()
+
+        # Assert
+        mock_poller1.stop.assert_awaited_once()
+        mock_poller2.stop.assert_awaited_once()
+
+    def test_extract_function_name_from_arn(self) -> None:
+        # Act
+        actual = _extract_function_name("arn:aws:lambda:us-east-1:000000000000:function:MyFunc")
+
+        # Assert
+        expected = "MyFunc"
+        assert actual == expected
+
+    def test_extract_function_name_plain(self) -> None:
+        # Act
+        actual = _extract_function_name("MyFunc")
+
+        # Assert
+        expected = "MyFunc"
+        assert actual == expected
+
+    def test_extract_queue_name(self) -> None:
+        # Act
+        actual = _extract_queue_name("arn:aws:sqs:us-east-1:000000000000:my-queue")
+
+        # Assert
+        expected = "my-queue"
+        assert actual == expected
+
+    def test_extract_table_name(self) -> None:
+        # Act
+        actual = _extract_table_name(
+            "arn:aws:dynamodb:us-east-1:000000000000:table/my-table/stream/123"
+        )
+
+        # Assert
+        expected = "my-table"
+        assert actual == expected

--- a/tests/unit/providers/test_lambda_routes_event_source_mappings.py
+++ b/tests/unit/providers/test_lambda_routes_event_source_mappings.py
@@ -1,0 +1,100 @@
+"""Tests for Lambda event source mapping API operations."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from lws.providers.lambda_runtime.routes import (
+    LambdaRegistry,
+    create_lambda_management_app,
+)
+
+
+@pytest.fixture
+def app():
+    """Create a Lambda management app."""
+    registry = LambdaRegistry()
+    return create_lambda_management_app(registry)
+
+
+@pytest.fixture
+async def client(app):
+    """Create an async HTTP client for the app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestEventSourceMappings:
+    """Event source mapping list, get, and delete operations."""
+
+    async def test_list_returns_stored_mappings(self, client: AsyncClient) -> None:
+        # Arrange
+        create_body = {
+            "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+            "FunctionName": "my-function",
+            "BatchSize": 5,
+        }
+        create_resp = await client.post("/2015-03-31/event-source-mappings", json=create_body)
+        expected_status = 202
+        assert create_resp.status_code == expected_status
+        esm_uuid = create_resp.json()["UUID"]
+
+        # Act
+        list_resp = await client.get("/2015-03-31/event-source-mappings")
+
+        # Assert
+        expected_list_status = 200
+        assert list_resp.status_code == expected_list_status
+        mappings = list_resp.json()["EventSourceMappings"]
+        expected_count = 1
+        actual_count = len(mappings)
+        assert actual_count == expected_count
+        actual_uuid = mappings[0]["UUID"]
+        assert actual_uuid == esm_uuid
+
+    async def test_get_returns_mapping_by_uuid(self, client: AsyncClient) -> None:
+        # Arrange
+        create_body = {
+            "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:get-queue",
+            "FunctionName": "get-function",
+        }
+        create_resp = await client.post("/2015-03-31/event-source-mappings", json=create_body)
+        esm_uuid = create_resp.json()["UUID"]
+
+        # Act
+        get_resp = await client.get(f"/2015-03-31/event-source-mappings/{esm_uuid}")
+
+        # Assert
+        expected_status = 200
+        assert get_resp.status_code == expected_status
+        actual_uuid = get_resp.json()["UUID"]
+        assert actual_uuid == esm_uuid
+
+    async def test_delete_removes_mapping(self, client: AsyncClient) -> None:
+        # Arrange
+        create_body = {
+            "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:del-queue",
+            "FunctionName": "del-function",
+        }
+        create_resp = await client.post("/2015-03-31/event-source-mappings", json=create_body)
+        esm_uuid = create_resp.json()["UUID"]
+
+        # Act
+        delete_resp = await client.delete(f"/2015-03-31/event-source-mappings/{esm_uuid}")
+
+        # Assert
+        expected_delete_status = 202
+        assert delete_resp.status_code == expected_delete_status
+        get_resp = await client.get(f"/2015-03-31/event-source-mappings/{esm_uuid}")
+        expected_not_found = 404
+        assert get_resp.status_code == expected_not_found
+
+    async def test_get_nonexistent_returns_404(self, client: AsyncClient) -> None:
+        # Act
+        resp = await client.get("/2015-03-31/event-source-mappings/nonexistent-uuid")
+
+        # Assert
+        expected_status = 404
+        assert resp.status_code == expected_status

--- a/tests/unit/providers/test_s3_provider_multipart.py
+++ b/tests/unit/providers/test_s3_provider_multipart.py
@@ -1,0 +1,91 @@
+"""Tests for S3 multipart upload operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lws.providers.s3.provider import S3Provider
+
+
+@pytest.fixture
+async def provider(tmp_path: Path):
+    p = S3Provider(data_dir=tmp_path, buckets=["test-bucket"])
+    await p.start()
+    yield p
+    await p.stop()
+
+
+class TestMultipartUpload:
+    @pytest.mark.asyncio
+    async def test_create_upload_parts_complete_merges_object(self, provider: S3Provider) -> None:
+        # Arrange
+        bucket = "test-bucket"
+        key = "large-file.bin"
+        part1 = b"hello "
+        part2 = b"world"
+        expected_body = b"hello world"
+
+        # Act
+        upload_id = provider.create_multipart_upload(bucket, key)
+        provider.upload_part(bucket, key, upload_id, 1, part1)
+        provider.upload_part(bucket, key, upload_id, 2, part2)
+        result = await provider.complete_multipart_upload(bucket, key, upload_id)
+
+        # Assert
+        actual_body = await provider.get_object(bucket, key)
+        assert actual_body == expected_body
+        expected_key = key
+        actual_key = result["Key"]
+        assert actual_key == expected_key
+        expected_bucket = bucket
+        actual_bucket = result["Bucket"]
+        assert actual_bucket == expected_bucket
+
+    @pytest.mark.asyncio
+    async def test_abort_removes_upload(self, provider: S3Provider) -> None:
+        # Arrange
+        bucket = "test-bucket"
+        key = "aborted.bin"
+        upload_id = provider.create_multipart_upload(bucket, key)
+        provider.upload_part(bucket, key, upload_id, 1, b"data")
+
+        # Act
+        provider.abort_multipart_upload(upload_id)
+
+        # Assert
+        with pytest.raises(KeyError):
+            provider.list_parts(upload_id)
+
+    @pytest.mark.asyncio
+    async def test_list_parts_returns_correct_info(self, provider: S3Provider) -> None:
+        # Arrange
+        bucket = "test-bucket"
+        key = "parts.bin"
+        part_data = b"abcdef"
+        upload_id = provider.create_multipart_upload(bucket, key)
+        provider.upload_part(bucket, key, upload_id, 1, part_data)
+
+        # Act
+        parts = provider.list_parts(upload_id)
+
+        # Assert
+        assert len(parts) == 1
+        expected_part_number = 1
+        actual_part_number = parts[0]["PartNumber"]
+        assert actual_part_number == expected_part_number
+        expected_size = len(part_data)
+        actual_size = parts[0]["Size"]
+        assert actual_size == expected_size
+
+    @pytest.mark.asyncio
+    async def test_complete_with_unknown_upload_id_raises(self, provider: S3Provider) -> None:
+        # Arrange
+        bucket = "test-bucket"
+        key = "missing.bin"
+        bad_upload_id = "nonexistent-id"
+
+        # Act / Assert
+        with pytest.raises(KeyError):
+            await provider.complete_multipart_upload(bucket, key, bad_upload_id)

--- a/tests/unit/providers/test_template_parser_event_source_mappings.py
+++ b/tests/unit/providers/test_template_parser_event_source_mappings.py
@@ -1,0 +1,80 @@
+"""Tests for template_parser extract_event_source_mappings."""
+
+from __future__ import annotations
+
+from lws.parser.template_parser import (
+    CfnResource,
+    extract_event_source_mappings,
+)
+
+
+class TestExtractEventSourceMappings:
+    """Extract event source mappings from CloudFormation resources."""
+
+    def test_extracts_sqs_mapping(self) -> None:
+        # Arrange
+        resources = [
+            CfnResource(
+                logical_id="MySqsMapping",
+                resource_type="AWS::Lambda::EventSourceMapping",
+                properties={
+                    "FunctionName": "MyFunction",
+                    "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+                    "BatchSize": 5,
+                },
+            ),
+        ]
+
+        # Act
+        result = extract_event_source_mappings(resources)
+
+        # Assert
+        expected_count = 1
+        actual_count = len(result)
+        assert actual_count == expected_count
+        expected_function = "MyFunction"
+        actual_function = result[0].function_name
+        assert actual_function == expected_function
+        expected_batch = 5
+        actual_batch = result[0].batch_size
+        assert actual_batch == expected_batch
+
+    def test_skips_non_mapping_resources(self) -> None:
+        # Arrange
+        resources = [
+            CfnResource(
+                logical_id="MyTable",
+                resource_type="AWS::DynamoDB::Table",
+                properties={"TableName": "test"},
+            ),
+        ]
+
+        # Act
+        result = extract_event_source_mappings(resources)
+
+        # Assert
+        expected_count = 0
+        actual_count = len(result)
+        assert actual_count == expected_count
+
+    def test_defaults_batch_size_and_enabled(self) -> None:
+        # Arrange
+        resources = [
+            CfnResource(
+                logical_id="MinimalMapping",
+                resource_type="AWS::Lambda::EventSourceMapping",
+                properties={
+                    "FunctionName": "Func",
+                    "EventSourceArn": "arn:aws:sqs:us-east-1:000000000000:q",
+                },
+            ),
+        ]
+
+        # Act
+        result = extract_event_source_mappings(resources)
+
+        # Assert
+        expected_batch = 10
+        actual_batch = result[0].batch_size
+        assert actual_batch == expected_batch
+        assert result[0].enabled is True

--- a/uv.lock
+++ b/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "local-web-services"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Adds **100+ new CLI commands** across 11 AWS services, covering both control plane and data plane operations for serverless architectures
- Adds **~280 new test files** (E2E + integration + unit) with full coverage for every new command
- Extracts shared helpers (`parse_json_option`, `json_request_output`) to eliminate code duplication
- Fixes pre-existing API Gateway provider bug with misnamed route handler parameters
- Bumps version from 0.7.1 to **0.8.0**

### New commands by service

| Service | New Commands | Examples |
|---|---|---|
| API Gateway | 43 | create-rest-api, create-resource, put-method, put-integration, create-stage, v2-create-api, v2-create-route |
| SQS | 10 | get-queue-url, send-message-batch, change-message-visibility, tag-queue |
| SNS | 10 | unsubscribe, get-topic-attributes, tag-resource, confirm-subscription |
| EventBridge | 10 | put-targets, describe-rule, enable-rule, tag-resource |
| Step Functions | 9 | start-sync-execution, update-state-machine, validate-state-machine-definition |
| Cognito | 9 | create-user-pool-client, admin-create-user, list-users |
| Secrets Manager | 6 | update-secret, restore-secret, tag-resource, get-resource-policy |
| SSM | 5 | get-parameters, delete-parameters, add-tags-to-resource |
| Lambda | 5 | get-function, delete-function, list-functions, update-function-configuration |
| DynamoDB | 4 | update-item, batch-write-item, batch-get-item, transact-get-items |

### Quality checks

- \`make check\` passes: ruff, black, radon, pylint (10.00/10), CPD (0 duplicates), 2238 tests passing

## Test plan

- [x] \`make check\` passes (lint, format, complexity, CPD, pylint, unit + integration tests)
- [x] \`make test-e2e\` passes for all serverless services (225 tests)
- [ ] Verify new CLI commands work with \`ldk dev\` in a real project

🤖 Generated with [Claude Code](https://claude.com/claude-code)