### PR TITLE
Add lang/specification with Gherkin feature files

### DIFF
--- a/lang/specification/core/features/apigateway/binary_payloads.feature
+++ b/lang/specification/core/features/apigateway/binary_payloads.feature
@@ -1,0 +1,12 @@
+@apigateway @binary_payloads @happy @dataplane @v2 @requires_docker
+Feature: API Gateway V2 Binary Payloads
+
+  Scenario: Binary request body is base64 encoded in the event
+    Given an echo Lambda "e2e-bin-echo" was created
+    And a V2 API "e2e-bin-payload" was created
+    And a V2 proxy integration for Lambda "e2e-bin-echo" was created
+    And a V2 route with key "POST /e2e-bin-upload" targeting the integration was created
+    When I test invoke POST on "/e2e-bin-upload" with binary content type
+    Then the command will succeed
+    And the invoke response status will be 200
+    And the invoke response body field "isBase64Encoded" will be "true"

--- a/lang/specification/core/features/apigateway/cors_preflight.feature
+++ b/lang/specification/core/features/apigateway/cors_preflight.feature
@@ -1,0 +1,11 @@
+@apigateway @cors_preflight @happy @dataplane @v2
+Feature: API Gateway V2 CORS Preflight
+
+  Scenario: OPTIONS request returns CORS headers
+    Given a V2 API "e2e-cors-preflight" was created with CORS allowing all origins
+    And a V2 integration with type "AWS_PROXY" was created
+    And a V2 route with key "GET /e2e-cors-items" targeting the integration was created
+    When I test invoke OPTIONS on "/e2e-cors-items" with origin "http://example.com"
+    Then the command will succeed
+    And the invoke response status will be 204
+    And the invoke response header "access-control-allow-origin" will contain "*"

--- a/lang/specification/core/features/apigateway/create_authorizer.feature
+++ b/lang/specification/core/features/apigateway/create_authorizer.feature
@@ -1,0 +1,24 @@
+@apigateway @create_authorizer @happy @controlplane
+Feature: API Gateway CreateAuthorizer
+
+  Scenario: Create an authorizer for a REST API
+    Given a REST API "e2e-create-authorizer" was created
+    When I create an authorizer named "my-auth" of type "TOKEN" for the REST API
+    Then the command will succeed
+    And the output will contain an "id" field
+    And the output "name" will be "my-auth"
+    And the output "type" will be "TOKEN"
+
+  Scenario: Get an authorizer for a REST API
+    Given a REST API "e2e-get-authorizer" was created
+    And an authorizer "my-auth" of type "TOKEN" was created for the REST API
+    When I get the authorizer
+    Then the command will succeed
+    And the output "name" will be "my-auth"
+
+  Scenario: List authorizers for a REST API
+    Given a REST API "e2e-list-authorizers" was created
+    And an authorizer "list-auth" of type "TOKEN" was created for the REST API
+    When I list authorizers for the REST API
+    Then the command will succeed
+    And the output will contain an "item" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/create_authorizer_v2.feature
+++ b/lang/specification/core/features/apigateway/create_authorizer_v2.feature
@@ -1,0 +1,24 @@
+@apigateway @create_authorizer_v2 @happy @controlplane @v2
+Feature: API Gateway V2 CreateAuthorizer
+
+  Scenario: Create an authorizer for an HTTP API
+    Given a V2 API "e2e-v2-create-authorizer" was created
+    When I create a V2 authorizer named "jwt-auth" of type "JWT" for the HTTP API
+    Then the command will succeed
+    And the output will contain an "authorizerId" field
+    And the output "name" will be "jwt-auth"
+    And the output "authorizerType" will be "JWT"
+
+  Scenario: Get an authorizer for an HTTP API
+    Given a V2 API "e2e-v2-get-authorizer" was created
+    And a V2 authorizer "jwt-auth" of type "JWT" was created for the HTTP API
+    When I get the V2 authorizer
+    Then the command will succeed
+    And the output "name" will be "jwt-auth"
+
+  Scenario: List authorizers for an HTTP API
+    Given a V2 API "e2e-v2-list-authorizers" was created
+    And a V2 authorizer "list-auth" of type "JWT" was created for the HTTP API
+    When I list V2 authorizers
+    Then the command will succeed
+    And the output will contain an "items" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/create_deployment.feature
+++ b/lang/specification/core/features/apigateway/create_deployment.feature
@@ -1,0 +1,8 @@
+@apigateway @create_deployment @happy @controlplane
+Feature: API Gateway CreateDeployment
+
+  Scenario: Create a deployment for a REST API
+    Given a REST API "e2e-create-deployment" was created
+    When I create a deployment for the REST API
+    Then the command will succeed
+    And the output will contain an "id" field

--- a/lang/specification/core/features/apigateway/create_resource.feature
+++ b/lang/specification/core/features/apigateway/create_resource.feature
@@ -1,0 +1,8 @@
+@apigateway @create_resource @happy @controlplane
+Feature: API Gateway CreateResource
+
+  Scenario: Create a resource under the root
+    Given a REST API "e2e-create-resource" was created
+    When I create a resource with path part "items" under the root
+    Then the command will succeed
+    And the output "path" will be "/items"

--- a/lang/specification/core/features/apigateway/create_rest_api.feature
+++ b/lang/specification/core/features/apigateway/create_rest_api.feature
@@ -1,0 +1,8 @@
+@apigateway @create_rest_api @happy @controlplane
+Feature: API Gateway CreateRestApi
+
+  Scenario: Create a new REST API
+    When I create a REST API named "e2e-create-rest-api"
+    Then the command will succeed
+    And the output will contain an "id" field
+    And the output "name" will be "e2e-create-rest-api"

--- a/lang/specification/core/features/apigateway/create_stage.feature
+++ b/lang/specification/core/features/apigateway/create_stage.feature
@@ -1,0 +1,9 @@
+@apigateway @create_stage @happy @controlplane
+Feature: API Gateway CreateStage
+
+  Scenario: Create a stage for a REST API
+    Given a REST API "e2e-create-stage" was created
+    And a deployment was created for the REST API
+    When I create a stage named "e2e-dev" for the REST API
+    Then the command will succeed
+    And the output "stageName" will be "e2e-dev"

--- a/lang/specification/core/features/apigateway/delete_integration.feature
+++ b/lang/specification/core/features/apigateway/delete_integration.feature
@@ -1,0 +1,10 @@
+@apigateway @delete_integration @happy @controlplane
+Feature: API Gateway DeleteIntegration
+
+  Scenario: Delete an integration from a method
+    Given a REST API "e2e-delete-integration" was created
+    And a resource "remove" was created under the root
+    And method "POST" was added to the resource
+    And integration type "AWS_PROXY" was added to method "POST"
+    When I delete integration for method "POST"
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/delete_method.feature
+++ b/lang/specification/core/features/apigateway/delete_method.feature
@@ -1,0 +1,9 @@
+@apigateway @delete_method @happy @controlplane
+Feature: API Gateway DeleteMethod
+
+  Scenario: Delete a method from a resource
+    Given a REST API "e2e-delete-method" was created
+    And a resource "temp" was created under the root
+    And method "DELETE" was added to the resource
+    When I delete method "DELETE" on the resource
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/delete_resource.feature
+++ b/lang/specification/core/features/apigateway/delete_resource.feature
@@ -1,0 +1,8 @@
+@apigateway @delete_resource @happy @controlplane
+Feature: API Gateway DeleteResource
+
+  Scenario: Delete a resource from a REST API
+    Given a REST API "e2e-delete-resource" was created
+    And a resource "to-delete" was created under the root
+    When I delete the resource
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/delete_rest_api.feature
+++ b/lang/specification/core/features/apigateway/delete_rest_api.feature
@@ -1,0 +1,7 @@
+@apigateway @delete_rest_api @happy @controlplane
+Feature: API Gateway DeleteRestApi
+
+  Scenario: Delete a REST API
+    Given a REST API "e2e-delete-rest-api" was created
+    When I delete the REST API
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/delete_stage.feature
+++ b/lang/specification/core/features/apigateway/delete_stage.feature
@@ -1,0 +1,9 @@
+@apigateway @delete_stage @happy @controlplane
+Feature: API Gateway DeleteStage
+
+  Scenario: Delete a stage from a REST API
+    Given a REST API "e2e-delete-stage" was created
+    And a deployment was created for the REST API
+    And a stage named "to-delete" was created for the REST API
+    When I delete stage "to-delete" for the REST API
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/get_deployment.feature
+++ b/lang/specification/core/features/apigateway/get_deployment.feature
@@ -1,0 +1,9 @@
+@apigateway @get_deployment @happy @controlplane
+Feature: API Gateway GetDeployment
+
+  Scenario: Get a deployment by ID
+    Given a REST API "e2e-get-deployment" was created
+    And a deployment was created for the REST API
+    When I get the deployment
+    Then the command will succeed
+    And the output "id" will match the deployment ID

--- a/lang/specification/core/features/apigateway/get_integration.feature
+++ b/lang/specification/core/features/apigateway/get_integration.feature
@@ -1,0 +1,11 @@
+@apigateway @get_integration @happy @controlplane
+Feature: API Gateway GetIntegration
+
+  Scenario: Get an integration on a method
+    Given a REST API "e2e-get-integration" was created
+    And a resource "data" was created under the root
+    And method "GET" was added to the resource
+    And integration type "AWS_PROXY" was added to method "GET"
+    When I get integration for method "GET"
+    Then the command will succeed
+    And the output "type" will be "AWS_PROXY"

--- a/lang/specification/core/features/apigateway/get_integration_response.feature
+++ b/lang/specification/core/features/apigateway/get_integration_response.feature
@@ -1,0 +1,12 @@
+@apigateway @get_integration_response @happy @controlplane
+Feature: API Gateway GetIntegrationResponse
+
+  Scenario: Get an integration response
+    Given a REST API "e2e-get-int-resp" was created
+    And a resource "getresp" was created under the root
+    And method "GET" was added to the resource
+    And integration type "FAKE" was added to method "GET"
+    And integration response with status "200" was added to method "GET"
+    When I get integration response with status "200" for method "GET"
+    Then the command will succeed
+    And the output "statusCode" will be "200"

--- a/lang/specification/core/features/apigateway/get_method.feature
+++ b/lang/specification/core/features/apigateway/get_method.feature
@@ -1,0 +1,10 @@
+@apigateway @get_method @happy @controlplane
+Feature: API Gateway GetMethod
+
+  Scenario: Get a method on a resource
+    Given a REST API "e2e-get-method" was created
+    And a resource "products" was created under the root
+    And method "GET" was added to the resource
+    When I get method "GET" on the resource
+    Then the command will succeed
+    And the output "httpMethod" will be "GET"

--- a/lang/specification/core/features/apigateway/get_method_response.feature
+++ b/lang/specification/core/features/apigateway/get_method_response.feature
@@ -1,0 +1,11 @@
+@apigateway @get_method_response @happy @controlplane
+Feature: API Gateway GetMethodResponse
+
+  Scenario: Get a method response
+    Given a REST API "e2e-get-method-resp" was created
+    And a resource "gmresp" was created under the root
+    And method "GET" was added to the resource
+    And method response with status "200" was added to method "GET"
+    When I get method response with status "200" for method "GET"
+    Then the command will succeed
+    And the output "statusCode" will be "200"

--- a/lang/specification/core/features/apigateway/get_resources.feature
+++ b/lang/specification/core/features/apigateway/get_resources.feature
@@ -1,0 +1,8 @@
+@apigateway @get_resources @happy @controlplane
+Feature: API Gateway GetResources
+
+  Scenario: Get resources for a REST API
+    Given a REST API "e2e-get-resources" was created
+    When I get resources for the REST API
+    Then the command will succeed
+    And the output will contain an "item" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/get_rest_api.feature
+++ b/lang/specification/core/features/apigateway/get_rest_api.feature
@@ -1,0 +1,8 @@
+@apigateway @get_rest_api @happy @controlplane
+Feature: API Gateway GetRestApi
+
+  Scenario: Get a REST API by ID
+    Given a REST API "e2e-get-rest-api" was created
+    When I get the REST API
+    Then the command will succeed
+    And the output "name" will be "e2e-get-rest-api"

--- a/lang/specification/core/features/apigateway/get_stage.feature
+++ b/lang/specification/core/features/apigateway/get_stage.feature
@@ -1,0 +1,10 @@
+@apigateway @get_stage @happy @controlplane
+Feature: API Gateway GetStage
+
+  Scenario: Get a stage by name
+    Given a REST API "e2e-get-stage" was created
+    And a deployment was created for the REST API
+    And a stage named "e2e-staging" was created for the REST API
+    When I get stage "e2e-staging" for the REST API
+    Then the command will succeed
+    And the output "stageName" will be "e2e-staging"

--- a/lang/specification/core/features/apigateway/list_deployments.feature
+++ b/lang/specification/core/features/apigateway/list_deployments.feature
@@ -1,0 +1,9 @@
+@apigateway @list_deployments @happy @controlplane
+Feature: API Gateway ListDeployments
+
+  Scenario: List deployments for a REST API
+    Given a REST API "e2e-list-deployments" was created
+    And a deployment was created for the REST API
+    When I list deployments for the REST API
+    Then the command will succeed
+    And the output will contain an "item" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/list_rest_apis.feature
+++ b/lang/specification/core/features/apigateway/list_rest_apis.feature
@@ -1,0 +1,8 @@
+@apigateway @list_rest_apis @happy @controlplane
+Feature: API Gateway ListRestApis
+
+  Scenario: List REST APIs
+    Given a REST API "e2e-list-rest-apis" was created
+    When I list REST APIs
+    Then the command will succeed
+    And the output will contain an "item" list

--- a/lang/specification/core/features/apigateway/multivalue_headers.feature
+++ b/lang/specification/core/features/apigateway/multivalue_headers.feature
@@ -1,0 +1,12 @@
+@apigateway @multivalue_headers @happy @dataplane @v2 @requires_docker
+Feature: API Gateway V2 Multi-Value Headers
+
+  Scenario: Custom header is passed to the Lambda event
+    Given an echo Lambda "e2e-mv-hdr-echo" was created
+    And a V2 API "e2e-mv-hdr" was created
+    And a V2 proxy integration for Lambda "e2e-mv-hdr-echo" was created
+    And a V2 route with key "$default" targeting the integration was created
+    When I test invoke GET on "/e2e-mv-hdr-test" with header "x-custom:hello"
+    Then the command will succeed
+    And the invoke response status will be 200
+    And the invoke response body field "headers.x-custom" will be "hello"

--- a/lang/specification/core/features/apigateway/multivalue_query_params.feature
+++ b/lang/specification/core/features/apigateway/multivalue_query_params.feature
@@ -1,0 +1,12 @@
+@apigateway @multivalue_query_params @happy @dataplane @v2 @requires_docker
+Feature: API Gateway V2 Multi-Value Query Parameters
+
+  Scenario: Repeated query parameters are comma-joined in the event
+    Given an echo Lambda "e2e-mv-qp-echo" was created
+    And a V2 API "e2e-mv-qp" was created
+    And a V2 proxy integration for Lambda "e2e-mv-qp-echo" was created
+    And a V2 route with key "$default" targeting the integration was created
+    When I test invoke GET on "/e2e-mv-qp-test?color=red&color=blue"
+    Then the command will succeed
+    And the invoke response status will be 200
+    And the invoke response body field "queryStringParameters.color" will be "red,blue"

--- a/lang/specification/core/features/apigateway/put_integration.feature
+++ b/lang/specification/core/features/apigateway/put_integration.feature
@@ -1,0 +1,10 @@
+@apigateway @put_integration @happy @controlplane
+Feature: API Gateway PutIntegration
+
+  Scenario: Put an integration on a method
+    Given a REST API "e2e-put-integration" was created
+    And a resource "items" was created under the root
+    And method "POST" was added to the resource
+    When I put integration type "AWS_PROXY" on method "POST"
+    Then the command will succeed
+    And the output "type" will be "AWS_PROXY"

--- a/lang/specification/core/features/apigateway/put_integration_response.feature
+++ b/lang/specification/core/features/apigateway/put_integration_response.feature
@@ -1,0 +1,11 @@
+@apigateway @put_integration_response @happy @controlplane
+Feature: API Gateway PutIntegrationResponse
+
+  Scenario: Put an integration response
+    Given a REST API "e2e-put-int-resp" was created
+    And a resource "resp" was created under the root
+    And method "GET" was added to the resource
+    And integration type "FAKE" was added to method "GET"
+    When I put integration response with status "200" on method "GET"
+    Then the command will succeed
+    And the output "statusCode" will be "200"

--- a/lang/specification/core/features/apigateway/put_method.feature
+++ b/lang/specification/core/features/apigateway/put_method.feature
@@ -1,0 +1,9 @@
+@apigateway @put_method @happy @controlplane
+Feature: API Gateway PutMethod
+
+  Scenario: Put a method on a resource
+    Given a REST API "e2e-put-method" was created
+    And a resource "orders" was created under the root
+    When I put method "GET" on the resource
+    Then the command will succeed
+    And the output "httpMethod" will be "GET"

--- a/lang/specification/core/features/apigateway/put_method_response.feature
+++ b/lang/specification/core/features/apigateway/put_method_response.feature
@@ -1,0 +1,10 @@
+@apigateway @put_method_response @happy @controlplane
+Feature: API Gateway PutMethodResponse
+
+  Scenario: Put a method response on a method
+    Given a REST API "e2e-put-method-resp" was created
+    And a resource "mresp" was created under the root
+    And method "GET" was added to the resource
+    When I put method response with status "200" on method "GET"
+    Then the command will succeed
+    And the output "statusCode" will be "200"

--- a/lang/specification/core/features/apigateway/test_invoke_method.feature
+++ b/lang/specification/core/features/apigateway/test_invoke_method.feature
@@ -1,0 +1,7 @@
+@apigateway @test_invoke_method @happy @controlplane
+Feature: API Gateway TestInvokeMethod
+
+  Scenario: Test invoke a method on a resource
+    When I test invoke method "GET" on resource "/health"
+    Then the command will succeed
+    And the output will contain a "status" field

--- a/lang/specification/core/features/apigateway/update_rest_api.feature
+++ b/lang/specification/core/features/apigateway/update_rest_api.feature
@@ -1,0 +1,8 @@
+@apigateway @update_rest_api @happy @controlplane
+Feature: API Gateway UpdateRestApi
+
+  Scenario: Update a REST API name
+    Given a REST API "e2e-update-rest-api" was created
+    When I update the REST API name to "e2e-updated"
+    Then the command will succeed
+    And the output "name" will be "e2e-updated"

--- a/lang/specification/core/features/apigateway/update_stage.feature
+++ b/lang/specification/core/features/apigateway/update_stage.feature
@@ -1,0 +1,10 @@
+@apigateway @update_stage @happy @controlplane
+Feature: API Gateway UpdateStage
+
+  Scenario: Update a stage
+    Given a REST API "e2e-update-stage" was created
+    And a deployment was created for the REST API
+    And a stage named "e2e-prod" was created for the REST API
+    When I update stage "e2e-prod" for the REST API
+    Then the command will succeed
+    And the output "stageName" will be "e2e-prod"

--- a/lang/specification/core/features/apigateway/v2_cors_configuration.feature
+++ b/lang/specification/core/features/apigateway/v2_cors_configuration.feature
@@ -1,0 +1,13 @@
+@apigateway @v2_cors_configuration @happy @controlplane @v2
+Feature: API Gateway V2 CORS Configuration
+
+  Scenario: Create a V2 API with CORS configuration
+    When I create a V2 API named "e2e-cors-config" with CORS allowing all origins
+    Then the command will succeed
+    And the output will contain a "corsConfiguration" field
+
+  Scenario: Get a V2 API returns CORS configuration
+    Given a V2 API "e2e-cors-get" was created with CORS allowing all origins
+    When I get the V2 API
+    Then the command will succeed
+    And the output will contain a "corsConfiguration" field

--- a/lang/specification/core/features/apigateway/v2_create_api.feature
+++ b/lang/specification/core/features/apigateway/v2_create_api.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_create_api @happy @controlplane @v2
+Feature: API Gateway V2 CreateApi
+
+  Scenario: Create a new HTTP API
+    When I create a V2 API named "e2e-v2-create-api"
+    Then the command will succeed
+    And the output will contain an "apiId" field
+    And the output "name" will be "e2e-v2-create-api"

--- a/lang/specification/core/features/apigateway/v2_create_integration.feature
+++ b/lang/specification/core/features/apigateway/v2_create_integration.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_create_integration @happy @controlplane @v2
+Feature: API Gateway V2 CreateIntegration
+
+  Scenario: Create an integration for an HTTP API
+    Given a V2 API "e2e-v2-create-int" was created
+    When I create a V2 integration with type "AWS_PROXY"
+    Then the command will succeed
+    And the output will contain an "integrationId" field
+    And the output "integrationType" will be "AWS_PROXY"

--- a/lang/specification/core/features/apigateway/v2_create_route.feature
+++ b/lang/specification/core/features/apigateway/v2_create_route.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_create_route @happy @controlplane @v2
+Feature: API Gateway V2 CreateRoute
+
+  Scenario: Create a route for an HTTP API
+    Given a V2 API "e2e-v2-create-route" was created
+    When I create a V2 route with key "GET /items"
+    Then the command will succeed
+    And the output will contain a "routeId" field
+    And the output "routeKey" will be "GET /items"

--- a/lang/specification/core/features/apigateway/v2_create_stage.feature
+++ b/lang/specification/core/features/apigateway/v2_create_stage.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_create_stage @happy @controlplane @v2
+Feature: API Gateway V2 CreateStage
+
+  Scenario: Create a stage for an HTTP API
+    Given a V2 API "e2e-v2-create-stage" was created
+    When I create a V2 stage named "e2e-dev"
+    Then the command will succeed
+    And the output "stageName" will be "e2e-dev"

--- a/lang/specification/core/features/apigateway/v2_delete_api.feature
+++ b/lang/specification/core/features/apigateway/v2_delete_api.feature
@@ -1,0 +1,7 @@
+@apigateway @v2_delete_api @happy @controlplane @v2
+Feature: API Gateway V2 DeleteApi
+
+  Scenario: Delete an HTTP API
+    Given a V2 API "e2e-v2-delete-api" was created
+    When I delete the V2 API
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/v2_delete_integration.feature
+++ b/lang/specification/core/features/apigateway/v2_delete_integration.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_delete_integration @happy @controlplane @v2
+Feature: API Gateway V2 DeleteIntegration
+
+  Scenario: Delete an integration from an HTTP API
+    Given a V2 API "e2e-v2-del-int" was created
+    And a V2 integration with type "AWS_PROXY" was created
+    When I delete the V2 integration
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/v2_delete_route.feature
+++ b/lang/specification/core/features/apigateway/v2_delete_route.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_delete_route @happy @controlplane @v2
+Feature: API Gateway V2 DeleteRoute
+
+  Scenario: Delete a route from an HTTP API
+    Given a V2 API "e2e-v2-del-route" was created
+    And a V2 route with key "DELETE /temp" was created
+    When I delete the V2 route
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/v2_delete_stage.feature
+++ b/lang/specification/core/features/apigateway/v2_delete_stage.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_delete_stage @happy @controlplane @v2
+Feature: API Gateway V2 DeleteStage
+
+  Scenario: Delete a stage from an HTTP API
+    Given a V2 API "e2e-v2-delete-stage" was created
+    And a V2 stage named "to-delete" was created
+    When I delete V2 stage "to-delete"
+    Then the command will succeed

--- a/lang/specification/core/features/apigateway/v2_get_api.feature
+++ b/lang/specification/core/features/apigateway/v2_get_api.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_get_api @happy @controlplane @v2
+Feature: API Gateway V2 GetApi
+
+  Scenario: Get an HTTP API by ID
+    Given a V2 API "e2e-v2-get-api" was created
+    When I get the V2 API
+    Then the command will succeed
+    And the output "name" will be "e2e-v2-get-api"

--- a/lang/specification/core/features/apigateway/v2_get_integration.feature
+++ b/lang/specification/core/features/apigateway/v2_get_integration.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_get_integration @happy @controlplane @v2
+Feature: API Gateway V2 GetIntegration
+
+  Scenario: Get an integration by ID
+    Given a V2 API "e2e-v2-get-int" was created
+    And a V2 integration with type "AWS_PROXY" was created
+    When I get the V2 integration
+    Then the command will succeed
+    And the output "integrationId" will match the integration ID

--- a/lang/specification/core/features/apigateway/v2_get_route.feature
+++ b/lang/specification/core/features/apigateway/v2_get_route.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_get_route @happy @controlplane @v2
+Feature: API Gateway V2 GetRoute
+
+  Scenario: Get a route by ID
+    Given a V2 API "e2e-v2-get-route" was created
+    And a V2 route with key "POST /data" was created
+    When I get the V2 route
+    Then the command will succeed
+    And the output "routeKey" will be "POST /data"

--- a/lang/specification/core/features/apigateway/v2_get_stage.feature
+++ b/lang/specification/core/features/apigateway/v2_get_stage.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_get_stage @happy @controlplane @v2
+Feature: API Gateway V2 GetStage
+
+  Scenario: Get a stage by name
+    Given a V2 API "e2e-v2-get-stage" was created
+    And a V2 stage named "e2e-staging" was created
+    When I get V2 stage "e2e-staging"
+    Then the command will succeed
+    And the output "stageName" will be "e2e-staging"

--- a/lang/specification/core/features/apigateway/v2_list_apis.feature
+++ b/lang/specification/core/features/apigateway/v2_list_apis.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_list_apis @happy @controlplane @v2
+Feature: API Gateway V2 ListApis
+
+  Scenario: List HTTP APIs
+    Given a V2 API "e2e-v2-list-apis" was created
+    When I list V2 APIs
+    Then the command will succeed
+    And the output will contain an "items" list

--- a/lang/specification/core/features/apigateway/v2_list_integrations.feature
+++ b/lang/specification/core/features/apigateway/v2_list_integrations.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_list_integrations @happy @controlplane @v2
+Feature: API Gateway V2 ListIntegrations
+
+  Scenario: List integrations for an HTTP API
+    Given a V2 API "e2e-v2-list-ints" was created
+    And a V2 integration with type "AWS_PROXY" was created
+    When I list V2 integrations
+    Then the command will succeed
+    And the output will contain an "items" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/v2_list_routes.feature
+++ b/lang/specification/core/features/apigateway/v2_list_routes.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_list_routes @happy @controlplane @v2
+Feature: API Gateway V2 ListRoutes
+
+  Scenario: List routes for an HTTP API
+    Given a V2 API "e2e-v2-list-routes" was created
+    And a V2 route with key "GET /orders" was created
+    When I list V2 routes
+    Then the command will succeed
+    And the output will contain an "items" list with at least 1 entry

--- a/lang/specification/core/features/apigateway/v2_list_stages.feature
+++ b/lang/specification/core/features/apigateway/v2_list_stages.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_list_stages @happy @controlplane @v2
+Feature: API Gateway V2 ListStages
+
+  Scenario: List stages for an HTTP API
+    Given a V2 API "e2e-v2-list-stages" was created
+    And a V2 stage named "test" was created
+    When I list V2 stages
+    Then the command will succeed
+    And the output will contain an "items" list

--- a/lang/specification/core/features/apigateway/v2_update_api.feature
+++ b/lang/specification/core/features/apigateway/v2_update_api.feature
@@ -1,0 +1,8 @@
+@apigateway @v2_update_api @happy @controlplane @v2
+Feature: API Gateway V2 UpdateApi
+
+  Scenario: Update an HTTP API name
+    Given a V2 API "e2e-v2-update-api" was created
+    When I update the V2 API name to "e2e-v2-updated"
+    Then the command will succeed
+    And the output "name" will be "e2e-v2-updated"

--- a/lang/specification/core/features/apigateway/v2_update_stage.feature
+++ b/lang/specification/core/features/apigateway/v2_update_stage.feature
@@ -1,0 +1,9 @@
+@apigateway @v2_update_stage @happy @controlplane @v2
+Feature: API Gateway V2 UpdateStage
+
+  Scenario: Update a stage for an HTTP API
+    Given a V2 API "e2e-v2-update-stage" was created
+    And a V2 stage named "e2e-prod" was created
+    When I update V2 stage "e2e-prod"
+    Then the command will succeed
+    And the output "stageName" will be "e2e-prod"

--- a/lang/specification/core/features/aws_fake/add_remove_operation.feature
+++ b/lang/specification/core/features/aws_fake/add_remove_operation.feature
@@ -1,0 +1,17 @@
+@aws_fake @add_remove_operation @controlplane
+Feature: AWS fake add and remove operations
+
+  @happy
+  Scenario: Add an operation to an AWS fake
+    Given an AWS fake "e2e-aws-fake-addop" for service "s3" was created
+    When I add operation "get-object" to AWS fake "e2e-aws-fake-addop" with status 200 and body "faked"
+    Then the command will succeed
+    And the AWS fake "e2e-aws-fake-addop" was cleaned up
+
+  @happy
+  Scenario: Remove an operation from an AWS fake
+    Given an AWS fake "e2e-aws-fake-rmop" for service "dynamodb" was created
+    And operation "get-item" was added to AWS fake "e2e-aws-fake-rmop"
+    When I remove operation "get-item" from AWS fake "e2e-aws-fake-rmop"
+    Then the command will succeed
+    And the AWS fake "e2e-aws-fake-rmop" was cleaned up

--- a/lang/specification/core/features/aws_fake/create_delete.feature
+++ b/lang/specification/core/features/aws_fake/create_delete.feature
@@ -1,0 +1,23 @@
+@aws_fake @create_delete @controlplane
+Feature: AWS fake create and delete
+
+  @happy
+  Scenario: Create an AWS fake for S3
+    When I create an AWS fake "e2e-aws-fake-s3" for service "s3"
+    Then the command will succeed
+    And the output will contain "e2e-aws-fake-s3"
+    And the AWS fake "e2e-aws-fake-s3" was cleaned up
+
+  @happy
+  Scenario: Create and delete an AWS fake
+    Given an AWS fake "e2e-aws-fake-delete" for service "dynamodb" was created
+    When I delete the AWS fake "e2e-aws-fake-delete"
+    Then the command will succeed
+
+  @happy
+  Scenario: List AWS fakes
+    Given an AWS fake "e2e-aws-fake-list" for service "sqs" was created
+    When I list AWS fakes
+    Then the command will succeed
+    And the output will contain "e2e-aws-fake-list"
+    And the AWS fake "e2e-aws-fake-list" was cleaned up

--- a/lang/specification/core/features/aws_fake/fake_fallthrough.feature
+++ b/lang/specification/core/features/aws_fake/fake_fallthrough.feature
@@ -1,0 +1,68 @@
+@aws_fake @fake_fallthrough @dataplane
+Feature: AWS fake falls through for unmatched operations
+
+  When a fake rule is configured for one operation, requests for
+  other operations reach the real provider unchanged.
+
+  @happy @dynamodb
+  Scenario: DynamoDB unfaked operation falls through
+    Given an AWS fake rule for "dynamodb" operation "get-item" was configured
+    When I list DynamoDB tables
+    Then the output will not contain "faked"
+    And the AWS fake rule for "dynamodb" was cleaned up
+
+  @happy @sqs
+  Scenario: SQS unfaked operation falls through
+    Given an AWS fake rule for "sqs" operation "send-message" was configured
+    When I list SQS queues
+    Then the output will not contain "faked"
+    And the AWS fake rule for "sqs" was cleaned up
+
+  @happy @s3
+  Scenario: S3 unfaked operation falls through
+    Given an AWS fake rule for "s3" operation "get-object" was configured
+    When I list S3 buckets
+    Then the output will not contain "faked"
+    And the AWS fake rule for "s3" was cleaned up
+
+  @happy @sns
+  Scenario: SNS unfaked operation falls through
+    Given an AWS fake rule for "sns" operation "publish" was configured
+    When I list SNS topics
+    Then the output will not contain "faked"
+    And the AWS fake rule for "sns" was cleaned up
+
+  @happy @stepfunctions
+  Scenario: Step Functions unfaked operation falls through
+    Given an AWS fake rule for "stepfunctions" operation "start-execution" was configured
+    When I list Step Functions state machines
+    Then the output will not contain "faked"
+    And the AWS fake rule for "stepfunctions" was cleaned up
+
+  @happy @events
+  Scenario: EventBridge unfaked operation falls through
+    Given an AWS fake rule for "events" operation "put-events" was configured
+    When I list EventBridge event buses
+    Then the output will not contain "faked"
+    And the AWS fake rule for "events" was cleaned up
+
+  @happy @cognito_idp
+  Scenario: Cognito unfaked operation falls through
+    Given an AWS fake rule for "cognito-idp" operation "initiate-auth" was configured
+    When I list Cognito user pools
+    Then the output will not contain "faked"
+    And the AWS fake rule for "cognito-idp" was cleaned up
+
+  @happy @ssm
+  Scenario: SSM unfaked operation falls through
+    Given an AWS fake rule for "ssm" operation "get-parameter" was configured
+    When I describe SSM parameters
+    Then the output will not contain "faked"
+    And the AWS fake rule for "ssm" was cleaned up
+
+  @happy @secretsmanager
+  Scenario: Secrets Manager unfaked operation falls through
+    Given an AWS fake rule for "secretsmanager" operation "get-secret-value" was configured
+    When I list Secrets Manager secrets
+    Then the output will not contain "faked"
+    And the AWS fake rule for "secretsmanager" was cleaned up

--- a/lang/specification/core/features/aws_fake/fake_header_filter.feature
+++ b/lang/specification/core/features/aws_fake/fake_header_filter.feature
@@ -1,0 +1,28 @@
+@aws_fake @fake_header_filter @dataplane
+Feature: AWS fake header-based filtering
+
+  Fake rules with header match criteria only activate when
+  the request contains the specified headers. The standard CLI
+  commands do not send the custom header so the fake should not
+  activate.
+
+  @happy @dynamodb
+  Scenario: DynamoDB header-filtered fake does not activate without header
+    Given an AWS fake rule for "dynamodb" operation "list-tables" with header filter was configured
+    When I list DynamoDB tables
+    Then the output will not contain "header-filtered-fake"
+    And the AWS fake rule for "dynamodb" was cleaned up
+
+  @happy @s3
+  Scenario: S3 header-filtered fake does not activate without header
+    Given an AWS fake rule for "s3" operation "list-buckets" with header filter was configured
+    When I list S3 buckets
+    Then the output will not contain "header-filtered-fake"
+    And the AWS fake rule for "s3" was cleaned up
+
+  @happy @ssm
+  Scenario: SSM header-filtered fake does not activate without header
+    Given an AWS fake rule for "ssm" operation "describe-parameters" with header filter was configured
+    When I describe SSM parameters
+    Then the output will not contain "header-filtered-fake"
+    And the AWS fake rule for "ssm" was cleaned up

--- a/lang/specification/core/features/aws_fake/fake_intercept.feature
+++ b/lang/specification/core/features/aws_fake/fake_intercept.feature
@@ -1,0 +1,67 @@
+@aws_fake @fake_intercept @dataplane
+Feature: AWS fake intercepts matched operations
+
+  Fake rules return canned responses for matched operations.
+
+  @happy @dynamodb
+  Scenario: DynamoDB fake intercepts ListTables
+    Given an AWS fake rule for "dynamodb" operation "list-tables" was configured
+    When I list DynamoDB tables
+    Then the output will contain "faked"
+    And the AWS fake rule for "dynamodb" was cleaned up
+
+  @happy @sqs
+  Scenario: SQS fake intercepts ListQueues
+    Given an AWS fake rule for "sqs" operation "list-queues" was configured
+    When I list SQS queues
+    Then the output will contain "faked"
+    And the AWS fake rule for "sqs" was cleaned up
+
+  @happy @s3
+  Scenario: S3 fake intercepts ListBuckets
+    Given an AWS fake rule for "s3" operation "list-buckets" was configured
+    When I list S3 buckets
+    Then the output will contain "faked"
+    And the AWS fake rule for "s3" was cleaned up
+
+  @happy @sns
+  Scenario: SNS fake intercepts ListTopics
+    Given an AWS fake rule for "sns" operation "list-topics" was configured
+    When I list SNS topics
+    Then the output will contain "faked"
+    And the AWS fake rule for "sns" was cleaned up
+
+  @happy @stepfunctions
+  Scenario: Step Functions fake intercepts ListStateMachines
+    Given an AWS fake rule for "stepfunctions" operation "list-state-machines" was configured
+    When I list Step Functions state machines
+    Then the output will contain "faked"
+    And the AWS fake rule for "stepfunctions" was cleaned up
+
+  @happy @events
+  Scenario: EventBridge fake intercepts ListEventBuses
+    Given an AWS fake rule for "events" operation "list-event-buses" was configured
+    When I list EventBridge event buses
+    Then the output will contain "faked"
+    And the AWS fake rule for "events" was cleaned up
+
+  @happy @cognito_idp
+  Scenario: Cognito fake intercepts ListUserPools
+    Given an AWS fake rule for "cognito-idp" operation "list-user-pools" was configured
+    When I list Cognito user pools
+    Then the output will contain "faked"
+    And the AWS fake rule for "cognito-idp" was cleaned up
+
+  @happy @ssm
+  Scenario: SSM fake intercepts DescribeParameters
+    Given an AWS fake rule for "ssm" operation "describe-parameters" was configured
+    When I describe SSM parameters
+    Then the output will contain "faked"
+    And the AWS fake rule for "ssm" was cleaned up
+
+  @happy @secretsmanager
+  Scenario: Secrets Manager fake intercepts ListSecrets
+    Given an AWS fake rule for "secretsmanager" operation "list-secrets" was configured
+    When I list Secrets Manager secrets
+    Then the output will contain "faked"
+    And the AWS fake rule for "secretsmanager" was cleaned up

--- a/lang/specification/core/features/chaos/enable_disable.feature
+++ b/lang/specification/core/features/chaos/enable_disable.feature
@@ -1,0 +1,133 @@
+@chaos @enable_disable @controlplane
+Feature: Chaos enable and disable
+
+  @happy
+  Scenario: Enable chaos for dynamodb
+    When I enable chaos for "dynamodb"
+    Then the command will succeed
+    And chaos for "dynamodb" will be enabled
+
+  @happy
+  Scenario: Disable chaos for dynamodb
+    Given chaos was enabled for "dynamodb"
+    When I disable chaos for "dynamodb"
+    Then the command will succeed
+    And chaos for "dynamodb" will be disabled
+
+  @happy
+  Scenario: Enable chaos for sqs
+    When I enable chaos for "sqs"
+    Then the command will succeed
+    And chaos for "sqs" will be enabled
+
+  @happy
+  Scenario: Disable chaos for sqs
+    Given chaos was enabled for "sqs"
+    When I disable chaos for "sqs"
+    Then the command will succeed
+    And chaos for "sqs" will be disabled
+
+  @happy
+  Scenario: Enable chaos for s3
+    When I enable chaos for "s3"
+    Then the command will succeed
+    And chaos for "s3" will be enabled
+
+  @happy
+  Scenario: Disable chaos for s3
+    Given chaos was enabled for "s3"
+    When I disable chaos for "s3"
+    Then the command will succeed
+    And chaos for "s3" will be disabled
+
+  @happy
+  Scenario: Enable chaos for sns
+    When I enable chaos for "sns"
+    Then the command will succeed
+    And chaos for "sns" will be enabled
+
+  @happy
+  Scenario: Disable chaos for sns
+    Given chaos was enabled for "sns"
+    When I disable chaos for "sns"
+    Then the command will succeed
+    And chaos for "sns" will be disabled
+
+  @happy
+  Scenario: Enable chaos for stepfunctions
+    When I enable chaos for "stepfunctions"
+    Then the command will succeed
+    And chaos for "stepfunctions" will be enabled
+
+  @happy
+  Scenario: Disable chaos for stepfunctions
+    Given chaos was enabled for "stepfunctions"
+    When I disable chaos for "stepfunctions"
+    Then the command will succeed
+    And chaos for "stepfunctions" will be disabled
+
+  @happy
+  Scenario: Enable chaos for events
+    When I enable chaos for "events"
+    Then the command will succeed
+    And chaos for "events" will be enabled
+
+  @happy
+  Scenario: Disable chaos for events
+    Given chaos was enabled for "events"
+    When I disable chaos for "events"
+    Then the command will succeed
+    And chaos for "events" will be disabled
+
+  @happy
+  Scenario: Enable chaos for cognito-idp
+    When I enable chaos for "cognito-idp"
+    Then the command will succeed
+    And chaos for "cognito-idp" will be enabled
+
+  @happy
+  Scenario: Disable chaos for cognito-idp
+    Given chaos was enabled for "cognito-idp"
+    When I disable chaos for "cognito-idp"
+    Then the command will succeed
+    And chaos for "cognito-idp" will be disabled
+
+  @happy
+  Scenario: Enable chaos for ssm
+    When I enable chaos for "ssm"
+    Then the command will succeed
+    And chaos for "ssm" will be enabled
+
+  @happy
+  Scenario: Disable chaos for ssm
+    Given chaos was enabled for "ssm"
+    When I disable chaos for "ssm"
+    Then the command will succeed
+    And chaos for "ssm" will be disabled
+
+  @happy
+  Scenario: Enable chaos for secretsmanager
+    When I enable chaos for "secretsmanager"
+    Then the command will succeed
+    And chaos for "secretsmanager" will be enabled
+
+  @happy
+  Scenario: Disable chaos for secretsmanager
+    Given chaos was enabled for "secretsmanager"
+    When I disable chaos for "secretsmanager"
+    Then the command will succeed
+    And chaos for "secretsmanager" will be disabled
+
+  @happy
+  Scenario: Show chaos status for all services
+    When I request chaos status
+    Then the command will succeed
+    And the chaos status will contain "dynamodb"
+    And the chaos status will contain "s3"
+    And the chaos status will contain "sqs"
+    And the chaos status will contain "sns"
+    And the chaos status will contain "stepfunctions"
+    And the chaos status will contain "events"
+    And the chaos status will contain "cognito-idp"
+    And the chaos status will contain "ssm"
+    And the chaos status will contain "secretsmanager"

--- a/lang/specification/core/features/chaos/error_injection.feature
+++ b/lang/specification/core/features/chaos/error_injection.feature
@@ -1,0 +1,68 @@
+@chaos @error_injection @dataplane
+Feature: Chaos error injection across AWS services
+
+  Chaos middleware injects errors in the correct wire-protocol format
+  for each AWS service when error rate is set to 100%.
+
+  @happy
+  Scenario: DynamoDB returns JSON error when chaos is active
+    Given chaos was configured for "dynamodb" with full error rate
+    When I list DynamoDB tables
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "dynamodb"
+
+  @happy
+  Scenario: SQS returns XML error when chaos is active
+    Given chaos was configured for "sqs" with full error rate
+    When I list SQS queues
+    Then the output will contain an XML chaos error
+    And chaos was cleaned up for "sqs"
+
+  @happy
+  Scenario: S3 returns XML error when chaos is active
+    Given chaos was configured for "s3" with full error rate
+    When I list S3 buckets
+    Then the output will contain an S3 XML chaos error
+    And chaos was cleaned up for "s3"
+
+  @happy
+  Scenario: SNS returns XML error when chaos is active
+    Given chaos was configured for "sns" with full error rate
+    When I list SNS topics
+    Then the output will contain an XML chaos error
+    And chaos was cleaned up for "sns"
+
+  @happy
+  Scenario: Step Functions returns JSON error when chaos is active
+    Given chaos was configured for "stepfunctions" with full error rate
+    When I list Step Functions state machines
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "stepfunctions"
+
+  @happy
+  Scenario: EventBridge returns JSON error when chaos is active
+    Given chaos was configured for "events" with full error rate
+    When I list EventBridge event buses
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "events"
+
+  @happy
+  Scenario: Cognito returns JSON error when chaos is active
+    Given chaos was configured for "cognito-idp" with full error rate
+    When I list Cognito user pools
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "cognito-idp"
+
+  @happy
+  Scenario: SSM returns JSON error when chaos is active
+    Given chaos was configured for "ssm" with full error rate
+    When I describe SSM parameters
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "ssm"
+
+  @happy
+  Scenario: Secrets Manager returns JSON error when chaos is active
+    Given chaos was configured for "secretsmanager" with full error rate
+    When I list Secrets Manager secrets
+    Then the output will contain a JSON chaos error
+    And chaos was cleaned up for "secretsmanager"

--- a/lang/specification/core/features/chaos/latency_injection.feature
+++ b/lang/specification/core/features/chaos/latency_injection.feature
@@ -1,0 +1,68 @@
+@chaos @latency_injection @dataplane
+Feature: Chaos latency injection across AWS services
+
+  Chaos middleware injects latency into service calls when configured.
+  Each scenario sets a fixed 200ms latency and verifies the call is delayed.
+
+  @happy
+  Scenario: DynamoDB call is delayed when latency chaos is active
+    Given chaos was configured for "dynamodb" with 200ms latency
+    When I list DynamoDB tables with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "dynamodb"
+
+  @happy
+  Scenario: SQS call is delayed when latency chaos is active
+    Given chaos was configured for "sqs" with 200ms latency
+    When I list SQS queues with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "sqs"
+
+  @happy
+  Scenario: S3 call is delayed when latency chaos is active
+    Given chaos was configured for "s3" with 200ms latency
+    When I list S3 buckets with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "s3"
+
+  @happy
+  Scenario: SNS call is delayed when latency chaos is active
+    Given chaos was configured for "sns" with 200ms latency
+    When I list SNS topics with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "sns"
+
+  @happy
+  Scenario: Step Functions call is delayed when latency chaos is active
+    Given chaos was configured for "stepfunctions" with 200ms latency
+    When I list Step Functions state machines with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "stepfunctions"
+
+  @happy
+  Scenario: EventBridge call is delayed when latency chaos is active
+    Given chaos was configured for "events" with 200ms latency
+    When I list EventBridge event buses with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "events"
+
+  @happy
+  Scenario: Cognito call is delayed when latency chaos is active
+    Given chaos was configured for "cognito-idp" with 200ms latency
+    When I list Cognito user pools with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "cognito-idp"
+
+  @happy
+  Scenario: SSM call is delayed when latency chaos is active
+    Given chaos was configured for "ssm" with 200ms latency
+    When I describe SSM parameters with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "ssm"
+
+  @happy
+  Scenario: Secrets Manager call is delayed when latency chaos is active
+    Given chaos was configured for "secretsmanager" with 200ms latency
+    When I list Secrets Manager secrets with timing
+    Then the call will have taken at least 200 milliseconds
+    And chaos was cleaned up for "secretsmanager"

--- a/lang/specification/core/features/chaos/set_config.feature
+++ b/lang/specification/core/features/chaos/set_config.feature
@@ -1,0 +1,77 @@
+@chaos @set_config @controlplane
+Feature: Chaos set configuration
+
+  @happy
+  Scenario: Set error rate for dynamodb
+    When I set chaos for "dynamodb" with error rate 0.5
+    Then the command will succeed
+    And chaos for "dynamodb" will have error rate 0.5
+
+  @happy
+  Scenario: Set latency for dynamodb
+    When I set chaos for "dynamodb" with latency min 50 and max 200
+    Then the command will succeed
+    And chaos for "dynamodb" will have latency min 50
+    And chaos for "dynamodb" will have latency max 200
+
+  @happy
+  Scenario: Set error rate for sqs
+    When I set chaos for "sqs" with error rate 0.3
+    Then the command will succeed
+    And chaos for "sqs" will have error rate 0.3
+
+  @happy
+  Scenario: Set error rate for s3
+    When I set chaos for "s3" with error rate 0.7
+    Then the command will succeed
+    And chaos for "s3" will have error rate 0.7
+
+  @happy
+  Scenario: Set error rate for sns
+    When I set chaos for "sns" with error rate 0.4
+    Then the command will succeed
+    And chaos for "sns" will have error rate 0.4
+
+  @happy
+  Scenario: Set latency for sqs
+    When I set chaos for "sqs" with latency min 100 and max 500
+    Then the command will succeed
+    And chaos for "sqs" will have latency min 100
+    And chaos for "sqs" will have latency max 500
+
+  @happy
+  Scenario: Set error rate for stepfunctions
+    When I set chaos for "stepfunctions" with error rate 0.2
+    Then the command will succeed
+    And chaos for "stepfunctions" will have error rate 0.2
+
+  @happy
+  Scenario: Set error rate for events
+    When I set chaos for "events" with error rate 0.6
+    Then the command will succeed
+    And chaos for "events" will have error rate 0.6
+
+  @happy
+  Scenario: Set error rate for cognito-idp
+    When I set chaos for "cognito-idp" with error rate 0.15
+    Then the command will succeed
+    And chaos for "cognito-idp" will have error rate 0.15
+
+  @happy
+  Scenario: Set error rate for ssm
+    When I set chaos for "ssm" with error rate 0.25
+    Then the command will succeed
+    And chaos for "ssm" will have error rate 0.25
+
+  @happy
+  Scenario: Set error rate for secretsmanager
+    When I set chaos for "secretsmanager" with error rate 0.35
+    Then the command will succeed
+    And chaos for "secretsmanager" will have error rate 0.35
+
+  @happy
+  Scenario: Set latency for stepfunctions
+    When I set chaos for "stepfunctions" with latency min 25 and max 150
+    Then the command will succeed
+    And chaos for "stepfunctions" will have latency min 25
+    And chaos for "stepfunctions" will have latency max 150

--- a/lang/specification/core/features/cognito_idp/admin_create_user.feature
+++ b/lang/specification/core/features/cognito_idp/admin_create_user.feature
@@ -1,0 +1,7 @@
+@cognito_idp @admin_create_user @happy @controlplane
+Feature: Cognito AdminCreateUser
+
+  Scenario: Admin-create a user in a pool
+    Given a user pool named "e2e-admin-create-pool" was created
+    When I admin-create user "e2e-admin-user" in pool "e2e-admin-create-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/admin_delete_user.feature
+++ b/lang/specification/core/features/cognito_idp/admin_delete_user.feature
@@ -1,0 +1,8 @@
+@cognito_idp @admin_delete_user @happy @controlplane
+Feature: Cognito AdminDeleteUser
+
+  Scenario: Admin-delete a user from a pool
+    Given a user pool named "e2e-admin-del-pool" was created
+    And user "e2e-admin-del-user" was admin-created in pool "e2e-admin-del-pool"
+    When I admin-delete user "e2e-admin-del-user" from pool "e2e-admin-del-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/admin_get_user.feature
+++ b/lang/specification/core/features/cognito_idp/admin_get_user.feature
@@ -1,0 +1,8 @@
+@cognito_idp @admin_get_user @happy @controlplane
+Feature: Cognito AdminGetUser
+
+  Scenario: Admin-get a confirmed user
+    Given a user pool named "e2e-admin-get-pool" was created
+    And a confirmed user "e2e-admin-get-user" existed in pool "e2e-admin-get-pool" with password "P@ssw0rd!123"
+    When I admin-get user "e2e-admin-get-user" from pool "e2e-admin-get-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/change_password.feature
+++ b/lang/specification/core/features/cognito_idp/change_password.feature
@@ -1,0 +1,9 @@
+@cognito_idp @change_password @happy @dataplane
+Feature: Cognito ChangePassword
+
+  Scenario: Change password via access token
+    Given a user pool named "e2e-change-pw-pool" was created
+    And an authenticated user "e2e-change-pw-user" existed in pool "e2e-change-pw-pool" with password "P@ssw0rd!123"
+    When I change password from "P@ssw0rd!123" to "N3wP@ssw0rd!" using the access token
+    Then the command will succeed
+    And user "e2e-change-pw-user" will authenticate in pool "e2e-change-pw-pool" with password "N3wP@ssw0rd!"

--- a/lang/specification/core/features/cognito_idp/confirm_forgot_password.feature
+++ b/lang/specification/core/features/cognito_idp/confirm_forgot_password.feature
@@ -1,0 +1,9 @@
+@cognito_idp @confirm_forgot_password @happy @dataplane
+Feature: Cognito ConfirmForgotPassword
+
+  Scenario: Confirm forgot password with bad code returns error
+    Given a user pool named "e2e-cfp-pool" was created
+    And a confirmed user "e2e-cfp-user" existed in pool "e2e-cfp-pool" with password "P@ssw0rd!123"
+    When I confirm forgot-password for user "e2e-cfp-user" in pool "e2e-cfp-pool" with code "000000" and password "N3wP@ss!456"
+    Then the command will succeed
+    And the output will contain a CodeMismatchException error

--- a/lang/specification/core/features/cognito_idp/confirm_sign_up.feature
+++ b/lang/specification/core/features/cognito_idp/confirm_sign_up.feature
@@ -1,0 +1,8 @@
+@cognito_idp @confirm_sign_up @happy @dataplane
+Feature: Cognito ConfirmSignUp
+
+  Scenario: Confirm a signed-up user
+    Given a user pool named "e2e-confirm-pool" was created
+    And user "e2e-confirmuser" was signed up in pool "e2e-confirm-pool" with password "P@ssw0rd!123"
+    When I confirm sign-up for user "e2e-confirmuser" in pool "e2e-confirm-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/create_user_pool.feature
+++ b/lang/specification/core/features/cognito_idp/create_user_pool.feature
@@ -1,0 +1,8 @@
+@cognito_idp @create_user_pool @happy @controlplane
+Feature: Cognito CreateUserPool
+
+  Scenario: Create a new user pool
+    When I create a user pool named "e2e-create-pool"
+    Then the command will succeed
+    And the output will contain a user pool named "e2e-create-pool"
+    And user pool "e2e-create-pool" will exist

--- a/lang/specification/core/features/cognito_idp/create_user_pool_client.feature
+++ b/lang/specification/core/features/cognito_idp/create_user_pool_client.feature
@@ -1,0 +1,7 @@
+@cognito_idp @create_user_pool_client @happy @controlplane
+Feature: Cognito CreateUserPoolClient
+
+  Scenario: Create a user pool client
+    Given a user pool named "e2e-create-upc-pool" was created
+    When I create a user pool client named "e2e-test-client" in pool "e2e-create-upc-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/delete_user_pool.feature
+++ b/lang/specification/core/features/cognito_idp/delete_user_pool.feature
@@ -1,0 +1,8 @@
+@cognito_idp @delete_user_pool @happy @controlplane
+Feature: Cognito DeleteUserPool
+
+  Scenario: Delete an existing user pool
+    Given a user pool named "e2e-del-pool" was created
+    When I delete user pool "e2e-del-pool"
+    Then the command will succeed
+    And the user pool list will not include "e2e-del-pool"

--- a/lang/specification/core/features/cognito_idp/delete_user_pool_client.feature
+++ b/lang/specification/core/features/cognito_idp/delete_user_pool_client.feature
@@ -1,0 +1,8 @@
+@cognito_idp @delete_user_pool_client @happy @controlplane
+Feature: Cognito DeleteUserPoolClient
+
+  Scenario: Delete a user pool client
+    Given a user pool named "e2e-del-upc-pool" was created
+    And a user pool client named "e2e-del-client" was created in pool "e2e-del-upc-pool"
+    When I delete the user pool client from pool "e2e-del-upc-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/describe_user_pool.feature
+++ b/lang/specification/core/features/cognito_idp/describe_user_pool.feature
@@ -1,0 +1,8 @@
+@cognito_idp @describe_user_pool @happy @controlplane
+Feature: Cognito DescribeUserPool
+
+  Scenario: Describe an existing user pool
+    Given a user pool named "e2e-desc-pool" was created
+    When I describe user pool "e2e-desc-pool"
+    Then the command will succeed
+    And the output will contain a user pool named "e2e-desc-pool"

--- a/lang/specification/core/features/cognito_idp/describe_user_pool_client.feature
+++ b/lang/specification/core/features/cognito_idp/describe_user_pool_client.feature
@@ -1,0 +1,8 @@
+@cognito_idp @describe_user_pool_client @happy @controlplane
+Feature: Cognito DescribeUserPoolClient
+
+  Scenario: Describe a user pool client
+    Given a user pool named "e2e-desc-upc-pool" was created
+    And a user pool client named "e2e-desc-client" was created in pool "e2e-desc-upc-pool"
+    When I describe the user pool client in pool "e2e-desc-upc-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/forgot_password.feature
+++ b/lang/specification/core/features/cognito_idp/forgot_password.feature
@@ -1,0 +1,12 @@
+@cognito_idp @forgot_password @happy @dataplane
+Feature: Cognito ForgotPassword
+
+  Scenario: Initiate forgot password and confirm with bad code
+    Given a user pool named "e2e-forgot-pw-pool" was created
+    And a confirmed user "e2e-forgot-user" existed in pool "e2e-forgot-pw-pool" with password "P@ssw0rd!123"
+    When I initiate forgot-password for user "e2e-forgot-user" in pool "e2e-forgot-pw-pool"
+    Then the command will succeed
+    And the output will contain CodeDeliveryDetails
+    When I confirm forgot-password for user "e2e-forgot-user" in pool "e2e-forgot-pw-pool" with code "000000" and password "N3wP@ssw0rd!"
+    Then the command will succeed
+    And the output will contain a CodeMismatchException error

--- a/lang/specification/core/features/cognito_idp/global_sign_out.feature
+++ b/lang/specification/core/features/cognito_idp/global_sign_out.feature
@@ -1,0 +1,8 @@
+@cognito_idp @global_sign_out @happy @dataplane
+Feature: Cognito GlobalSignOut
+
+  Scenario: Global sign out with access token
+    Given a user pool named "e2e-signout-pool" was created
+    And an authenticated user "e2e-signout-user" existed in pool "e2e-signout-pool" with password "P@ssw0rd!123"
+    When I global-sign-out using the access token
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/initiate_auth.feature
+++ b/lang/specification/core/features/cognito_idp/initiate_auth.feature
@@ -1,0 +1,9 @@
+@cognito_idp @initiate_auth @happy @dataplane
+Feature: Cognito InitiateAuth
+
+  Scenario: Authenticate a confirmed user
+    Given a user pool named "e2e-auth-pool" was created
+    And a confirmed user "e2e-authuser" existed in pool "e2e-auth-pool" with password "P@ssw0rd!123"
+    When I initiate auth for user "e2e-authuser" in pool "e2e-auth-pool" with password "P@ssw0rd!123"
+    Then the command will succeed
+    And the output will contain an AuthenticationResult

--- a/lang/specification/core/features/cognito_idp/list_user_pool_clients.feature
+++ b/lang/specification/core/features/cognito_idp/list_user_pool_clients.feature
@@ -1,0 +1,7 @@
+@cognito_idp @list_user_pool_clients @happy @controlplane
+Feature: Cognito ListUserPoolClients
+
+  Scenario: List user pool clients
+    Given a user pool named "e2e-list-upc-pool" was created
+    When I list user pool clients in pool "e2e-list-upc-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/list_user_pools.feature
+++ b/lang/specification/core/features/cognito_idp/list_user_pools.feature
@@ -1,0 +1,8 @@
+@cognito_idp @list_user_pools @happy @controlplane
+Feature: Cognito ListUserPools
+
+  Scenario: List user pools includes a created pool
+    Given a user pool named "e2e-list-pools" was created
+    When I list user pools
+    Then the command will succeed
+    And the user pool list will include "e2e-list-pools"

--- a/lang/specification/core/features/cognito_idp/list_users.feature
+++ b/lang/specification/core/features/cognito_idp/list_users.feature
@@ -1,0 +1,7 @@
+@cognito_idp @list_users @happy @controlplane
+Feature: Cognito ListUsers
+
+  Scenario: List users in a pool
+    Given a user pool named "e2e-list-users-pool" was created
+    When I list users in pool "e2e-list-users-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/cognito_idp/sign_up.feature
+++ b/lang/specification/core/features/cognito_idp/sign_up.feature
@@ -1,0 +1,8 @@
+@cognito_idp @sign_up @happy @dataplane
+Feature: Cognito SignUp
+
+  Scenario: Sign up a new user
+    Given a user pool named "e2e-signup-pool" was created
+    When I sign up user "testuser" in pool "e2e-signup-pool" with password "P@ssw0rd!123"
+    Then the command will succeed
+    And the output will contain a UserConfirmed field

--- a/lang/specification/core/features/cognito_idp/update_user_pool.feature
+++ b/lang/specification/core/features/cognito_idp/update_user_pool.feature
@@ -1,0 +1,7 @@
+@cognito_idp @update_user_pool @happy @controlplane
+Feature: Cognito UpdateUserPool
+
+  Scenario: Update an existing user pool
+    Given a user pool named "e2e-update-pool" was created
+    When I update user pool "e2e-update-pool"
+    Then the command will succeed

--- a/lang/specification/core/features/docdb/create_db_cluster.feature
+++ b/lang/specification/core/features/docdb/create_db_cluster.feature
@@ -1,0 +1,22 @@
+@docdb @create_db_cluster @controlplane
+Feature: DocDB CreateDBCluster
+
+  @happy
+  Scenario: Create a new DB cluster
+    When I create a DocDB cluster "e2e-docdb-create"
+    Then the command will succeed
+    And DocDB cluster "e2e-docdb-create" will exist
+
+  @happy
+  Scenario: Describe a DB cluster by identifier
+    Given a DocDB cluster "e2e-docdb-desc-id" was created
+    When I describe DocDB clusters with identifier "e2e-docdb-desc-id"
+    Then the command will succeed
+    And the output will contain exactly one cluster "e2e-docdb-desc-id"
+
+  @happy
+  Scenario: Delete an existing DB cluster
+    Given a DocDB cluster "e2e-docdb-delete" was created
+    When I delete DocDB cluster "e2e-docdb-delete"
+    Then the command will succeed
+    And DocDB cluster "e2e-docdb-delete" will not exist

--- a/lang/specification/core/features/dynamodb/batch_get_item.feature
+++ b/lang/specification/core/features/dynamodb/batch_get_item.feature
@@ -1,0 +1,9 @@
+@dynamodb @batch_get_item @dataplane
+Feature: DynamoDB BatchGetItem
+
+  @happy
+  Scenario: Batch get items from a table
+    Given a table "e2e-batch-get" was created
+    And an item was put with key "bg1" and data "hello" into table "e2e-batch-get"
+    When I batch get item with key "bg1" from table "e2e-batch-get"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/batch_write_item.feature
+++ b/lang/specification/core/features/dynamodb/batch_write_item.feature
@@ -1,0 +1,8 @@
+@dynamodb @batch_write_item @dataplane
+Feature: DynamoDB BatchWriteItem
+
+  @happy
+  Scenario: Batch write items into a table
+    Given a table "e2e-batch-write" was created
+    When I batch write items with keys "bw1" and "bw2" into table "e2e-batch-write"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/create_table.feature
+++ b/lang/specification/core/features/dynamodb/create_table.feature
@@ -1,0 +1,9 @@
+@dynamodb @create_table @controlplane
+Feature: DynamoDB CreateTable
+
+  @happy
+  Scenario: Create a new table
+    When I create a table "e2e-create-tbl"
+    Then the command will succeed
+    And the output will contain table name "e2e-create-tbl"
+    And table "e2e-create-tbl" will exist

--- a/lang/specification/core/features/dynamodb/delete_item.feature
+++ b/lang/specification/core/features/dynamodb/delete_item.feature
@@ -1,0 +1,10 @@
+@dynamodb @delete_item @dataplane
+Feature: DynamoDB DeleteItem
+
+  @happy
+  Scenario: Delete an existing item
+    Given a table "e2e-del-item" was created
+    And an item was put with key "k1" into table "e2e-del-item"
+    When I delete item with key "k1" from table "e2e-del-item"
+    Then the command will succeed
+    And table "e2e-del-item" will have 0 items

--- a/lang/specification/core/features/dynamodb/delete_table.feature
+++ b/lang/specification/core/features/dynamodb/delete_table.feature
@@ -1,0 +1,9 @@
+@dynamodb @delete_table @controlplane
+Feature: DynamoDB DeleteTable
+
+  @happy
+  Scenario: Delete an existing table
+    Given a table "e2e-del-tbl" was created
+    When I delete table "e2e-del-tbl"
+    Then the command will succeed
+    And table "e2e-del-tbl" will not appear in list-tables

--- a/lang/specification/core/features/dynamodb/describe_continuous_backups.feature
+++ b/lang/specification/core/features/dynamodb/describe_continuous_backups.feature
@@ -1,0 +1,8 @@
+@dynamodb @describe_continuous_backups @controlplane
+Feature: DynamoDB DescribeContinuousBackups
+
+  @happy
+  Scenario: Describe continuous backups for a table
+    Given a table "e2e-desc-backups" was created
+    When I describe continuous backups for table "e2e-desc-backups"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/describe_table.feature
+++ b/lang/specification/core/features/dynamodb/describe_table.feature
@@ -1,0 +1,9 @@
+@dynamodb @describe_table @controlplane
+Feature: DynamoDB DescribeTable
+
+  @happy
+  Scenario: Describe an existing table
+    Given a table "e2e-desc-tbl" was created
+    When I describe table "e2e-desc-tbl"
+    Then the command will succeed
+    And the output will contain table name "e2e-desc-tbl"

--- a/lang/specification/core/features/dynamodb/describe_time_to_live.feature
+++ b/lang/specification/core/features/dynamodb/describe_time_to_live.feature
@@ -1,0 +1,8 @@
+@dynamodb @describe_time_to_live @controlplane
+Feature: DynamoDB DescribeTimeToLive
+
+  @happy
+  Scenario: Describe TTL settings for a table
+    Given a table "e2e-desc-ttl" was created
+    When I describe time to live for table "e2e-desc-ttl"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/get_item.feature
+++ b/lang/specification/core/features/dynamodb/get_item.feature
@@ -1,0 +1,10 @@
+@dynamodb @get_item @dataplane
+Feature: DynamoDB GetItem
+
+  @happy
+  Scenario: Get an existing item
+    Given a table "e2e-get-item" was created
+    And an item was put with key "k1" and data "found" into table "e2e-get-item"
+    When I get item with key "k1" from table "e2e-get-item"
+    Then the command will succeed
+    And the output will contain item data "found"

--- a/lang/specification/core/features/dynamodb/list_tables.feature
+++ b/lang/specification/core/features/dynamodb/list_tables.feature
@@ -1,0 +1,9 @@
+@dynamodb @list_tables @controlplane
+Feature: DynamoDB ListTables
+
+  @happy
+  Scenario: List tables includes a known table
+    Given a table "e2e-list-tbl" was created
+    When I list tables
+    Then the command will succeed
+    And the table list will include "e2e-list-tbl"

--- a/lang/specification/core/features/dynamodb/list_tags_of_resource.feature
+++ b/lang/specification/core/features/dynamodb/list_tags_of_resource.feature
@@ -1,0 +1,9 @@
+@dynamodb @list_tags_of_resource @controlplane
+Feature: DynamoDB ListTagsOfResource
+
+  @happy
+  Scenario: List tags for a DynamoDB table
+    Given a table "e2e-ddb-listtags" was created
+    And table "e2e-ddb-listtags" was tagged with key "env" and value "prod"
+    When I list tags of table "e2e-ddb-listtags"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/put_item.feature
+++ b/lang/specification/core/features/dynamodb/put_item.feature
@@ -1,0 +1,9 @@
+@dynamodb @put_item @dataplane
+Feature: DynamoDB PutItem
+
+  @happy
+  Scenario: Put an item into a table
+    Given a table "e2e-put-item" was created
+    When I put an item with key "k1" and data "hello" into table "e2e-put-item"
+    Then the command will succeed
+    And item with key "k1" in table "e2e-put-item" will have data "hello"

--- a/lang/specification/core/features/dynamodb/query.feature
+++ b/lang/specification/core/features/dynamodb/query.feature
@@ -1,0 +1,11 @@
+@dynamodb @query @dataplane
+Feature: DynamoDB Query
+
+  @happy
+  Scenario: Query items by partition key
+    Given a table "e2e-query" was created
+    And an item was put with key "q1" and data "found" into table "e2e-query"
+    When I query table "e2e-query" for key "q1"
+    Then the command will succeed
+    And the query result will contain at least 1 item
+    And the first query result will have data "found"

--- a/lang/specification/core/features/dynamodb/scan.feature
+++ b/lang/specification/core/features/dynamodb/scan.feature
@@ -1,0 +1,13 @@
+@dynamodb @scan @dataplane
+Feature: DynamoDB Scan
+
+  @happy
+  Scenario: Scan returns all items in a table
+    Given a table "e2e-scan" was created
+    And an item was put with key "s1" and data "a" into table "e2e-scan"
+    And an item was put with key "s2" and data "b" into table "e2e-scan"
+    When I scan table "e2e-scan"
+    Then the command will succeed
+    And the scan result will contain at least 2 items
+    And the scan result will include key "s1"
+    And the scan result will include key "s2"

--- a/lang/specification/core/features/dynamodb/tag_resource.feature
+++ b/lang/specification/core/features/dynamodb/tag_resource.feature
@@ -1,0 +1,8 @@
+@dynamodb @tag_resource @controlplane
+Feature: DynamoDB TagResource
+
+  @happy
+  Scenario: Tag a DynamoDB table
+    Given a table "e2e-ddb-tag" was created
+    When I tag table "e2e-ddb-tag" with key "env" and value "test"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/transact_get_items.feature
+++ b/lang/specification/core/features/dynamodb/transact_get_items.feature
@@ -1,0 +1,9 @@
+@dynamodb @transact_get_items @dataplane
+Feature: DynamoDB TransactGetItems
+
+  @happy
+  Scenario: Transactionally get items from a table
+    Given a table "e2e-transact-get" was created
+    And an item was put with key "tg1" and data "value" into table "e2e-transact-get"
+    When I transact get item with key "tg1" from table "e2e-transact-get"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/transact_write_items.feature
+++ b/lang/specification/core/features/dynamodb/transact_write_items.feature
@@ -1,0 +1,18 @@
+@dynamodb @transact_write_items @dataplane
+Feature: DynamoDB TransactWriteItems
+
+  @happy
+  Scenario: Condition check passes and allows writes
+    Given a table "e2e-transact-cc-pass" was created
+    And an item was put with key "guard" and status "ok" into table "e2e-transact-cc-pass"
+    When I transact write with condition check on key "guard" and put key "new-item" with data "written" in table "e2e-transact-cc-pass"
+    Then the command will succeed
+    And item with key "new-item" in table "e2e-transact-cc-pass" will have data "written"
+
+  @happy
+  Scenario: Condition check fails and blocks writes
+    Given a table "e2e-transact-cc-fail" was created
+    When I transact write with condition check on key "nonexistent" and put key "blocked" with data "nope" in table "e2e-transact-cc-fail"
+    Then the command will succeed
+    And the output will contain a TransactionCanceledException
+    And item with key "blocked" will not exist in table "e2e-transact-cc-fail"

--- a/lang/specification/core/features/dynamodb/untag_resource.feature
+++ b/lang/specification/core/features/dynamodb/untag_resource.feature
@@ -1,0 +1,9 @@
+@dynamodb @untag_resource @controlplane
+Feature: DynamoDB UntagResource
+
+  @happy
+  Scenario: Untag a DynamoDB table
+    Given a table "e2e-ddb-untag" was created
+    And table "e2e-ddb-untag" was tagged with key "env" and value "test"
+    When I untag table "e2e-ddb-untag" removing key "env"
+    Then the command will succeed

--- a/lang/specification/core/features/dynamodb/update_item.feature
+++ b/lang/specification/core/features/dynamodb/update_item.feature
@@ -1,0 +1,10 @@
+@dynamodb @update_item @dataplane
+Feature: DynamoDB UpdateItem
+
+  @happy
+  Scenario: Update an existing item
+    Given a table "e2e-update-item" was created
+    And an item was put with key "k1" and data "original" into table "e2e-update-item"
+    When I update item with key "k1" setting data to "updated" in table "e2e-update-item"
+    Then the command will succeed
+    And item with key "k1" in table "e2e-update-item" will have data "updated"

--- a/lang/specification/core/features/dynamodb/update_table.feature
+++ b/lang/specification/core/features/dynamodb/update_table.feature
@@ -1,0 +1,9 @@
+@dynamodb @update_table @controlplane
+Feature: DynamoDB UpdateTable
+
+  @happy
+  Scenario: Update table billing mode
+    Given a table "e2e-update-tbl" was created
+    When I update table "e2e-update-tbl" with billing mode "PAY_PER_REQUEST"
+    Then the command will succeed
+    And table "e2e-update-tbl" will exist

--- a/lang/specification/core/features/dynamodb/update_time_to_live.feature
+++ b/lang/specification/core/features/dynamodb/update_time_to_live.feature
@@ -1,0 +1,8 @@
+@dynamodb @update_time_to_live @controlplane
+Feature: DynamoDB UpdateTimeToLive
+
+  @happy
+  Scenario: Update TTL settings for a table
+    Given a table "e2e-upd-ttl" was created
+    When I update time to live for table "e2e-upd-ttl"
+    Then the command will succeed

--- a/lang/specification/core/features/elasticache/create_cache_cluster.feature
+++ b/lang/specification/core/features/elasticache/create_cache_cluster.feature
@@ -1,0 +1,22 @@
+@elasticache @create_cache_cluster @controlplane
+Feature: ElastiCache CreateCacheCluster
+
+  @happy
+  Scenario: Create a cache cluster
+    When I create a cache cluster "e2e-create-cache-cluster"
+    Then the command will succeed
+    And cache cluster "e2e-create-cache-cluster" will have status "available"
+
+  @happy
+  Scenario: Describe cache clusters lists a created cluster
+    Given a cache cluster "e2e-describe-cache-clusters" was created
+    When I describe cache clusters
+    Then the command will succeed
+    And cache cluster "e2e-describe-cache-clusters" will appear in the list
+
+  @happy
+  Scenario: Delete a cache cluster
+    Given a cache cluster "e2e-delete-cache-cluster" was created
+    When I delete cache cluster "e2e-delete-cache-cluster"
+    Then the command will succeed
+    And cache cluster "e2e-delete-cache-cluster" will not appear in the list

--- a/lang/specification/core/features/elasticsearch/create_domain.feature
+++ b/lang/specification/core/features/elasticsearch/create_domain.feature
@@ -1,0 +1,22 @@
+@elasticsearch @create_elasticsearch_domain @controlplane
+Feature: Elasticsearch CreateElasticsearchDomain
+
+  @happy
+  Scenario: Create a new Elasticsearch domain
+    When I create elasticsearch domain "e2e-es-create-domain"
+    Then the command will succeed
+    And elasticsearch domain "e2e-es-create-domain" will exist
+
+  @happy
+  Scenario: List domains includes a created domain
+    Given an elasticsearch domain "e2e-es-create-list" was created
+    When I list elasticsearch domain names
+    Then the command will succeed
+    And the elasticsearch domain list will include "e2e-es-create-list"
+
+  @happy
+  Scenario: Delete an existing Elasticsearch domain
+    Given an elasticsearch domain "e2e-es-create-del" was created
+    When I delete elasticsearch domain "e2e-es-create-del"
+    Then the command will succeed
+    And the elasticsearch domain list will not include "e2e-es-create-del"

--- a/lang/specification/core/features/events/create_event_bus.feature
+++ b/lang/specification/core/features/events/create_event_bus.feature
@@ -1,0 +1,8 @@
+@events @create_event_bus @controlplane
+Feature: Events CreateEventBus
+
+  @happy
+  Scenario: Create a new event bus
+    When I create event bus "e2e-create-bus"
+    Then the command will succeed
+    And event bus "e2e-create-bus" will appear in list-event-buses

--- a/lang/specification/core/features/events/delete_event_bus.feature
+++ b/lang/specification/core/features/events/delete_event_bus.feature
@@ -1,0 +1,9 @@
+@events @delete_event_bus @controlplane
+Feature: Events DeleteEventBus
+
+  @happy
+  Scenario: Delete an existing event bus
+    Given an event bus "e2e-del-bus" was created
+    When I delete event bus "e2e-del-bus"
+    Then the command will succeed
+    And event bus "e2e-del-bus" will not appear in list-event-buses

--- a/lang/specification/core/features/events/delete_rule.feature
+++ b/lang/specification/core/features/events/delete_rule.feature
@@ -1,0 +1,9 @@
+@events @delete_rule @controlplane
+Feature: Events DeleteRule
+
+  @happy
+  Scenario: Delete an existing rule
+    Given a rule "e2e-del-rule" was created on event bus "default"
+    When I delete rule "e2e-del-rule"
+    Then the command will succeed
+    And rule "e2e-del-rule" will not appear in list-rules on event bus "default"

--- a/lang/specification/core/features/events/describe_event_bus.feature
+++ b/lang/specification/core/features/events/describe_event_bus.feature
@@ -1,0 +1,7 @@
+@events @describe_event_bus @controlplane
+Feature: Events DescribeEventBus
+
+  @happy
+  Scenario: Describe the default event bus
+    When I describe event bus "default"
+    Then the command will succeed

--- a/lang/specification/core/features/events/describe_rule.feature
+++ b/lang/specification/core/features/events/describe_rule.feature
@@ -1,0 +1,8 @@
+@events @describe_rule @controlplane
+Feature: Events DescribeRule
+
+  @happy
+  Scenario: Describe an existing rule
+    Given a rule "e2e-desc-rule" was created on event bus "default"
+    When I describe rule "e2e-desc-rule" on event bus "default"
+    Then the command will succeed

--- a/lang/specification/core/features/events/disable_rule.feature
+++ b/lang/specification/core/features/events/disable_rule.feature
@@ -1,0 +1,9 @@
+@events @disable_rule @controlplane
+Feature: Events DisableRule
+
+  @happy
+  Scenario: Disable an existing rule
+    Given a rule "e2e-disable-rule" was created on event bus "default"
+    When I disable rule "e2e-disable-rule" on event bus "default"
+    Then the command will succeed
+    And rule "e2e-disable-rule" will have state "DISABLED"

--- a/lang/specification/core/features/events/enable_rule.feature
+++ b/lang/specification/core/features/events/enable_rule.feature
@@ -1,0 +1,9 @@
+@events @enable_rule @controlplane
+Feature: Events EnableRule
+
+  @happy
+  Scenario: Enable an existing rule
+    Given a rule "e2e-enable-rule" was created on event bus "default"
+    When I enable rule "e2e-enable-rule" on event bus "default"
+    Then the command will succeed
+    And rule "e2e-enable-rule" will have state "ENABLED"

--- a/lang/specification/core/features/events/list_event_buses.feature
+++ b/lang/specification/core/features/events/list_event_buses.feature
@@ -1,0 +1,9 @@
+@events @list_event_buses @controlplane
+Feature: Events ListEventBuses
+
+  @happy
+  Scenario: List event buses includes a created bus
+    Given an event bus "e2e-list-bus" was created
+    When I list event buses
+    Then the command will succeed
+    And the output will contain event bus "e2e-list-bus"

--- a/lang/specification/core/features/events/list_rules.feature
+++ b/lang/specification/core/features/events/list_rules.feature
@@ -1,0 +1,8 @@
+@events @list_rules @controlplane
+Feature: Events ListRules
+
+  @happy
+  Scenario: List rules on the default bus
+    When I list rules on event bus "default"
+    Then the command will succeed
+    And the output will contain a Rules key

--- a/lang/specification/core/features/events/list_tags_for_resource.feature
+++ b/lang/specification/core/features/events/list_tags_for_resource.feature
@@ -1,0 +1,8 @@
+@events @list_tags_for_resource @controlplane
+Feature: Events ListTagsForResource
+
+  @happy
+  Scenario: List tags for an event bus
+    Given an event bus "e2e-list-tags-bus" was created
+    When I list tags for resource "arn:aws:events:us-east-1:000000000000:event-bus/e2e-list-tags-bus"
+    Then the command will succeed

--- a/lang/specification/core/features/events/list_targets_by_rule.feature
+++ b/lang/specification/core/features/events/list_targets_by_rule.feature
@@ -1,0 +1,8 @@
+@events @list_targets_by_rule @controlplane
+Feature: Events ListTargetsByRule
+
+  @happy
+  Scenario: List targets for an existing rule
+    Given a rule "e2e-list-targets-rule" was created on event bus "default"
+    When I list targets by rule "e2e-list-targets-rule" on event bus "default"
+    Then the command will succeed

--- a/lang/specification/core/features/events/put_events.feature
+++ b/lang/specification/core/features/events/put_events.feature
@@ -1,0 +1,8 @@
+@events @put_events @dataplane
+Feature: Events PutEvents
+
+  @happy
+  Scenario: Put events to the default bus
+    When I put events to the default bus
+    Then the command will succeed
+    And the failed entry count will be 0

--- a/lang/specification/core/features/events/put_rule.feature
+++ b/lang/specification/core/features/events/put_rule.feature
@@ -1,0 +1,8 @@
+@events @put_rule @controlplane
+Feature: Events PutRule
+
+  @happy
+  Scenario: Put a new rule on the default bus
+    When I put rule "e2e-put-rule" on event bus "default"
+    Then the command will succeed
+    And rule "e2e-put-rule" will appear in list-rules on event bus "default"

--- a/lang/specification/core/features/events/put_targets.feature
+++ b/lang/specification/core/features/events/put_targets.feature
@@ -1,0 +1,9 @@
+@events @put_targets @controlplane
+Feature: Events PutTargets
+
+  @happy
+  Scenario: Put targets on an existing rule
+    Given a rule "e2e-put-targets-rule" was created on event bus "default"
+    When I put targets on rule "e2e-put-targets-rule" on event bus "default"
+    Then the command will succeed
+    And rule "e2e-put-targets-rule" will have a target in list-targets-by-rule

--- a/lang/specification/core/features/events/remove_targets.feature
+++ b/lang/specification/core/features/events/remove_targets.feature
@@ -1,0 +1,10 @@
+@events @remove_targets @controlplane
+Feature: Events RemoveTargets
+
+  @happy
+  Scenario: Remove targets from an existing rule
+    Given a rule "e2e-rm-targets-rule" was created on event bus "default"
+    And targets were added to rule "e2e-rm-targets-rule" on event bus "default"
+    When I remove targets from rule "e2e-rm-targets-rule" on event bus "default"
+    Then the command will succeed
+    And rule "e2e-rm-targets-rule" will have no targets

--- a/lang/specification/core/features/events/tag_resource.feature
+++ b/lang/specification/core/features/events/tag_resource.feature
@@ -1,0 +1,9 @@
+@events @tag_resource @controlplane
+Feature: Events TagResource
+
+  @happy
+  Scenario: Tag an event bus
+    Given an event bus "e2e-tag-bus" was created
+    When I tag resource "arn:aws:events:us-east-1:000000000000:event-bus/e2e-tag-bus"
+    Then the command will succeed
+    And event bus "e2e-tag-bus" will have tag "env" with value "test"

--- a/lang/specification/core/features/events/untag_resource.feature
+++ b/lang/specification/core/features/events/untag_resource.feature
@@ -1,0 +1,10 @@
+@events @untag_resource @controlplane
+Feature: Events UntagResource
+
+  @happy
+  Scenario: Untag an event bus
+    Given an event bus "e2e-untag-bus" was created
+    And resource "arn:aws:events:us-east-1:000000000000:event-bus/e2e-untag-bus" was tagged
+    When I untag resource "arn:aws:events:us-east-1:000000000000:event-bus/e2e-untag-bus"
+    Then the command will succeed
+    And event bus "e2e-untag-bus" will not have tag "env"

--- a/lang/specification/core/features/fake/add_route.feature
+++ b/lang/specification/core/features/fake/add_route.feature
@@ -1,0 +1,31 @@
+@fake @add_route @controlplane
+Feature: Fake Add Route
+
+  @happy
+  Scenario: Add a route to a fake server
+    Given a fake server "e2e-fake-add-route" was created
+    When I add route "/v1/items" with method "GET" and status 200 to "e2e-fake-add-route"
+    Then the command will succeed
+    And the route file will exist for "/v1/items" with method "GET" in "e2e-fake-add-route"
+
+  @happy
+  Scenario: Add a POST route with a custom body
+    Given a fake server "e2e-fake-add-post" was created
+    When I add route "/v1/orders" with method "POST" and status 201 and body '{"created": true}' to "e2e-fake-add-post"
+    Then the command will succeed
+    And the route file will exist for "/v1/orders" with method "POST" in "e2e-fake-add-post"
+
+  @happy
+  Scenario: Add multiple routes to a fake server
+    Given a fake server "e2e-fake-multi-route" was created
+    And a route "/v1/alpha" with method "GET" and status 200 was added to "e2e-fake-multi-route"
+    When I add route "/v1/beta" with method "POST" and status 201 to "e2e-fake-multi-route"
+    Then the command will succeed
+    And the route file will exist for "/v1/alpha" with method "GET" in "e2e-fake-multi-route"
+    And the route file will exist for "/v1/beta" with method "POST" in "e2e-fake-multi-route"
+
+  @error
+  Scenario: Add a route to a nonexistent fake server
+    When I add route "/v1/test" with method "GET" and status 200 to "e2e-fake-add-missing"
+    Then the command will fail
+    And the output will contain "not found"

--- a/lang/specification/core/features/fake/chaos.feature
+++ b/lang/specification/core/features/fake/chaos.feature
@@ -1,0 +1,68 @@
+@fake @chaos @controlplane
+Feature: Fake Chaos Configuration
+
+  @happy
+  Scenario: New server has chaos disabled by default
+    Given a fake server "e2e-fake-chaos-default" was created
+    When I get status of fake server "e2e-fake-chaos-default"
+    Then the command will succeed
+    And the config will have chaos disabled
+
+  @happy
+  Scenario: Chaos config has zero error rate by default
+    Given a fake server "e2e-fake-chaos-error-rate" was created
+    When I read the config of fake server "e2e-fake-chaos-error-rate"
+    Then the chaos error rate will be 0.0
+
+  @happy
+  Scenario: Chaos config has zero latency by default
+    Given a fake server "e2e-fake-chaos-latency" was created
+    When I read the config of fake server "e2e-fake-chaos-latency"
+    Then the chaos latency min will be 0
+    And the chaos latency max will be 0
+
+  @happy
+  Scenario: Chaos config has zero connection reset rate by default
+    Given a fake server "e2e-fake-chaos-conn-reset" was created
+    When I read the config of fake server "e2e-fake-chaos-conn-reset"
+    Then the chaos connection reset rate will be 0.0
+
+  @happy
+  Scenario: Chaos config has zero timeout rate by default
+    Given a fake server "e2e-fake-chaos-timeout" was created
+    When I read the config of fake server "e2e-fake-chaos-timeout"
+    Then the chaos timeout rate will be 0.0
+
+  @happy
+  Scenario: Chaos config with custom latency values
+    Given a fake server "e2e-fake-chaos-latency-set" was created with chaos latency min 100 and max 500
+    When I read the config of fake server "e2e-fake-chaos-latency-set"
+    Then the chaos latency min will be 100
+    And the chaos latency max will be 500
+
+  @happy
+  Scenario: Chaos config with custom timeout rate
+    Given a fake server "e2e-fake-chaos-timeout-set" was created with chaos timeout rate 0.15
+    When I read the config of fake server "e2e-fake-chaos-timeout-set"
+    Then the chaos timeout rate will be 0.15
+
+  @happy
+  Scenario: Chaos config with custom error rate
+    Given a fake server "e2e-fake-chaos-error-set" was created with chaos error rate 0.25
+    When I read the config of fake server "e2e-fake-chaos-error-set"
+    Then the chaos error rate will be 0.25
+
+  @happy
+  Scenario: Chaos config with custom connection reset rate
+    Given a fake server "e2e-fake-chaos-reset-set" was created with chaos connection reset rate 0.05
+    When I read the config of fake server "e2e-fake-chaos-reset-set"
+    Then the chaos connection reset rate will be 0.05
+
+  @happy
+  Scenario: Chaos config with all custom values
+    Given a fake server "e2e-fake-chaos-all" was created with chaos latency min 50 and max 200 and error rate 0.1 and timeout rate 0.05
+    When I read the config of fake server "e2e-fake-chaos-all"
+    Then the chaos latency min will be 50
+    And the chaos latency max will be 200
+    And the chaos error rate will be 0.1
+    And the chaos timeout rate will be 0.05

--- a/lang/specification/core/features/fake/create_server.feature
+++ b/lang/specification/core/features/fake/create_server.feature
@@ -1,0 +1,40 @@
+@fake @create @controlplane
+Feature: Fake Create Server
+
+  @happy
+  Scenario: Create a new fake server
+    When I create fake server "e2e-fake-create-test"
+    Then the command will succeed
+    And the fake server directory will exist
+
+  @happy
+  Scenario: Create a fake server with a fixed port
+    When I create fake server "e2e-fake-create-port" with port 4100
+    Then the command will succeed
+    And the output will contain fake server "e2e-fake-create-port"
+    And the config will have port 4100
+
+  @happy
+  Scenario: Create a fake server with a description
+    When I create fake server "e2e-fake-create-desc" with description "My test API"
+    Then the command will succeed
+    And the config will have description "My test API"
+
+  @happy
+  Scenario: Create a fake server defaults to rest protocol
+    When I create fake server "e2e-fake-create-default-proto"
+    Then the command will succeed
+    And the config will have protocol "rest"
+
+  @happy
+  Scenario: Create a fake server with chaos disabled by default
+    When I create fake server "e2e-fake-create-chaos"
+    Then the command will succeed
+    And the config will have chaos disabled
+
+  @error
+  Scenario: Create a fake server that already exists
+    Given a fake server "e2e-fake-create-dup" was created
+    When I create fake server "e2e-fake-create-dup"
+    Then the command will fail
+    And the output will contain "already exists"

--- a/lang/specification/core/features/fake/delete_server.feature
+++ b/lang/specification/core/features/fake/delete_server.feature
@@ -1,0 +1,15 @@
+@fake @delete @controlplane
+Feature: Fake Delete Server
+
+  @happy
+  Scenario: Delete a fake server
+    Given a fake server "e2e-fake-delete-test" was created
+    When I delete fake server "e2e-fake-delete-test"
+    Then the command will succeed
+    And fake server "e2e-fake-delete-test" will not exist
+
+  @error
+  Scenario: Delete a fake server that does not exist
+    When I delete fake server "e2e-fake-delete-nonexistent"
+    Then the command will fail
+    And the output will contain "not found"

--- a/lang/specification/core/features/fake/graphql.feature
+++ b/lang/specification/core/features/fake/graphql.feature
@@ -1,0 +1,15 @@
+@fake @graphql @controlplane
+Feature: Fake GraphQL
+
+  @happy
+  Scenario: Create fake server with graphql protocol
+    When I create fake server "e2e-fake-graphql-create" with protocol "graphql"
+    Then the command will succeed
+    And the config will have protocol "graphql"
+
+  @happy
+  Scenario: GraphQL server status shows protocol
+    Given a fake server "e2e-fake-graphql-status" was created with protocol "graphql"
+    When I get status of fake server "e2e-fake-graphql-status"
+    Then the command will succeed
+    And the output will have protocol "graphql"

--- a/lang/specification/core/features/fake/grpc.feature
+++ b/lang/specification/core/features/fake/grpc.feature
@@ -1,0 +1,22 @@
+@fake @grpc @controlplane
+Feature: Fake gRPC
+
+  @happy
+  Scenario: Create fake server with grpc protocol
+    When I create fake server "e2e-fake-grpc-create" with protocol "grpc"
+    Then the command will succeed
+    And the config will have protocol "grpc"
+
+  @happy
+  Scenario: gRPC server appears in list
+    Given a fake server "e2e-fake-grpc-list" was created with protocol "grpc"
+    When I list fake servers
+    Then the command will succeed
+    And the output will contain fake server "e2e-fake-grpc-list"
+
+  @happy
+  Scenario: gRPC server status shows protocol
+    Given a fake server "e2e-fake-grpc-status" was created with protocol "grpc"
+    When I get status of fake server "e2e-fake-grpc-status"
+    Then the command will succeed
+    And the output will have protocol "grpc"

--- a/lang/specification/core/features/fake/header_routing.feature
+++ b/lang/specification/core/features/fake/header_routing.feature
@@ -1,0 +1,18 @@
+@fake @header_routing @controlplane
+Feature: Fake Header Routing
+
+  @happy
+  Scenario: Add a route with response headers
+    Given a fake server "e2e-fake-header-route" was created
+    When I add route "/v1/data" with method "GET" and status 200 and header "X-Custom:test-value" to "e2e-fake-header-route"
+    Then the command will succeed
+    And the route file will exist for "/v1/data" with method "GET" in "e2e-fake-header-route"
+
+  @happy
+  Scenario: Route file for different methods on same path
+    Given a fake server "e2e-fake-header-methods" was created
+    And a route "/v1/resource" with method "GET" and status 200 was added to "e2e-fake-header-methods"
+    When I add route "/v1/resource" with method "POST" and status 201 to "e2e-fake-header-methods"
+    Then the command will succeed
+    And the route file will exist for "/v1/resource" with method "GET" in "e2e-fake-header-methods"
+    And the route file will exist for "/v1/resource" with method "POST" in "e2e-fake-header-methods"

--- a/lang/specification/core/features/fake/import_spec.feature
+++ b/lang/specification/core/features/fake/import_spec.feature
@@ -1,0 +1,36 @@
+@fake @import_spec @controlplane
+Feature: Fake Import Spec
+
+  @happy
+  Scenario: Import an OpenAPI spec generates route files
+    Given a fake server "e2e-fake-import-spec" was created
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I import the spec file into "e2e-fake-import-spec"
+    Then the command will succeed
+    And the output will show 2 imported files
+    And the spec file will be copied to the fake server directory
+
+  @happy
+  Scenario: Import does not overwrite existing routes by default
+    Given a fake server "e2e-fake-import-no-overwrite" was created
+    And a route "/v1/users" with method "GET" and status 200 was added to "e2e-fake-import-no-overwrite"
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I import the spec file into "e2e-fake-import-no-overwrite"
+    Then the command will succeed
+    And the output will show 1 imported files
+
+  @happy
+  Scenario: Import with overwrite replaces existing routes
+    Given a fake server "e2e-fake-import-overwrite" was created
+    And a route "/v1/users" with method "GET" and status 200 was added to "e2e-fake-import-overwrite"
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I import the spec file into "e2e-fake-import-overwrite" with overwrite
+    Then the command will succeed
+    And the output will show 2 imported files
+
+  @error
+  Scenario: Import spec into nonexistent fake server
+    Given an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I import the spec file into "e2e-fake-import-missing"
+    Then the command will fail
+    And the output will contain "not found"

--- a/lang/specification/core/features/fake/invoke.feature
+++ b/lang/specification/core/features/fake/invoke.feature
@@ -1,0 +1,21 @@
+@fake @invoke @controlplane
+Feature: Fake Invoke
+
+  @happy
+  Scenario: Status shows route count after adding routes
+    Given a fake server "e2e-fake-invoke-count" was created
+    And a route "/v1/items" with method "GET" and status 200 was added to "e2e-fake-invoke-count"
+    When I get status of fake server "e2e-fake-invoke-count"
+    Then the command will succeed
+    And the output will show 1 route(s)
+
+  @happy
+  Scenario: Status shows updated count after removing a route
+    Given a fake server "e2e-fake-invoke-remove" was created
+    And a route "/v1/alpha" with method "GET" and status 200 was added to "e2e-fake-invoke-remove"
+    And a route "/v1/beta" with method "POST" and status 201 was added to "e2e-fake-invoke-remove"
+    When I remove route "/v1/alpha" with method "GET" from "e2e-fake-invoke-remove"
+    Then the command will succeed
+    When I get status of fake server "e2e-fake-invoke-remove"
+    Then the command will succeed
+    And the output will show 1 route(s)

--- a/lang/specification/core/features/fake/list_servers.feature
+++ b/lang/specification/core/features/fake/list_servers.feature
@@ -1,0 +1,26 @@
+@fake @list @controlplane
+Feature: Fake List Servers
+
+  @happy
+  Scenario: List fake servers when none exist
+    When I list fake servers
+    Then the command will succeed
+    And the output will show 0 servers
+
+  @happy
+  Scenario: List fake servers after creating one
+    Given a fake server "e2e-fake-list-single" was created
+    When I list fake servers
+    Then the command will succeed
+    And the output will contain fake server "e2e-fake-list-single"
+    And the output will show 1 server(s)
+
+  @happy
+  Scenario: List fake servers after creating multiple
+    Given a fake server "e2e-fake-list-alpha" was created
+    And a fake server "e2e-fake-list-beta" was created
+    When I list fake servers
+    Then the command will succeed
+    And the output will show 2 server(s)
+    And the output will contain fake server "e2e-fake-list-alpha"
+    And the output will contain fake server "e2e-fake-list-beta"

--- a/lang/specification/core/features/fake/remove_route.feature
+++ b/lang/specification/core/features/fake/remove_route.feature
@@ -1,0 +1,17 @@
+@fake @remove_route @controlplane
+Feature: Fake Remove Route
+
+  @happy
+  Scenario: Remove a route from a fake server
+    Given a fake server "e2e-fake-remove-route" was created
+    And a route "/v1/data" with method "POST" and status 201 was added to "e2e-fake-remove-route"
+    When I remove route "/v1/data" with method "POST" from "e2e-fake-remove-route"
+    Then the command will succeed
+    And the route file will not exist for "/v1/data" with method "POST" in "e2e-fake-remove-route"
+
+  @error
+  Scenario: Remove a route that does not exist
+    Given a fake server "e2e-fake-remove-missing" was created
+    When I remove route "/v1/nope" with method "GET" from "e2e-fake-remove-missing"
+    Then the command will fail
+    And the output will contain "not found"

--- a/lang/specification/core/features/fake/status.feature
+++ b/lang/specification/core/features/fake/status.feature
@@ -1,0 +1,32 @@
+@fake @status @controlplane
+Feature: Fake Server Status
+
+  @happy
+  Scenario: Get status of a fake server with no routes
+    Given a fake server "e2e-fake-status-empty" was created
+    When I get status of fake server "e2e-fake-status-empty"
+    Then the command will succeed
+    And the output will contain fake server "e2e-fake-status-empty"
+    And the output will show 0 route(s)
+
+  @happy
+  Scenario: Get status shows route count
+    Given a fake server "e2e-fake-status-routes" was created
+    And a route "/v1/items" with method "GET" and status 200 was added to "e2e-fake-status-routes"
+    And a route "/v1/orders" with method "POST" and status 201 was added to "e2e-fake-status-routes"
+    When I get status of fake server "e2e-fake-status-routes"
+    Then the command will succeed
+    And the output will show 2 route(s)
+
+  @happy
+  Scenario: Get status shows protocol
+    Given a fake server "e2e-fake-status-proto" was created with protocol "graphql"
+    When I get status of fake server "e2e-fake-status-proto"
+    Then the command will succeed
+    And the output will have protocol "graphql"
+
+  @error
+  Scenario: Get status of nonexistent fake server
+    When I get status of fake server "e2e-fake-status-missing"
+    Then the command will fail
+    And the output will contain "not found"

--- a/lang/specification/core/features/fake/validate.feature
+++ b/lang/specification/core/features/fake/validate.feature
@@ -1,0 +1,38 @@
+@fake @validate @controlplane
+Feature: Fake Validate
+
+  @happy
+  Scenario: Validate passes when fake covers all spec paths
+    Given a fake server "e2e-fake-validate-pass" was created
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    And the spec file was imported into "e2e-fake-validate-pass"
+    When I validate fake server "e2e-fake-validate-pass"
+    Then the command will succeed
+    And the validation result will be valid
+
+  @happy
+  Scenario: Validate warns about uncovered spec paths
+    Given a fake server "e2e-fake-validate-uncovered" was created
+    And a route "/v1/users" with method "GET" and status 200 was added to "e2e-fake-validate-uncovered"
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I validate fake server "e2e-fake-validate-uncovered" against the spec file
+    Then the command will succeed
+    And the validation result will have issues
+
+  @happy
+  Scenario: Validate warns about extra fake routes not in spec
+    Given a fake server "e2e-fake-validate-extra" was created
+    And a route "/v1/users" with method "GET" and status 200 was added to "e2e-fake-validate-extra"
+    And a route "/v1/extra" with method "GET" and status 200 was added to "e2e-fake-validate-extra"
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I validate fake server "e2e-fake-validate-extra" against the spec file
+    Then the command will succeed
+    And the validation result will have issues
+
+  @error
+  Scenario: Validate in strict mode fails on warnings
+    Given a fake server "e2e-fake-validate-strict" was created
+    And a route "/v1/users" with method "GET" and status 200 was added to "e2e-fake-validate-strict"
+    And an OpenAPI spec file exists with paths "/v1/users" and "/v1/orders"
+    When I validate fake server "e2e-fake-validate-strict" against the spec file in strict mode
+    Then the command will fail

--- a/lang/specification/core/features/glacier/create_vault.feature
+++ b/lang/specification/core/features/glacier/create_vault.feature
@@ -1,0 +1,14 @@
+@glacier @create_vault @controlplane
+Feature: Glacier CreateVault
+
+  @happy
+  Scenario: Create a new vault
+    When I create vault "e2e-create-vault"
+    Then the command will succeed
+    And vault "e2e-create-vault" will exist
+
+  @happy
+  Scenario: Create vault is idempotent
+    Given a vault "e2e-idempotent-vault" was created
+    When I create vault "e2e-idempotent-vault"
+    Then the command will succeed

--- a/lang/specification/core/features/glacier/list_vaults.feature
+++ b/lang/specification/core/features/glacier/list_vaults.feature
@@ -1,0 +1,9 @@
+@glacier @list_vaults @controlplane
+Feature: Glacier ListVaults
+
+  @happy
+  Scenario: List vaults includes a created vault
+    Given a vault "e2e-list-vaults" was created
+    When I list vaults
+    Then the command will succeed
+    And the vault list will include "e2e-list-vaults"

--- a/lang/specification/core/features/iam_auth/audit_mode.feature
+++ b/lang/specification/core/features/iam_auth/audit_mode.feature
@@ -1,0 +1,19 @@
+@iam_auth @audit_mode @dataplane
+Feature: IAM auth audit mode logs but allows requests
+
+  When audit mode is active, requests from unknown identities are logged
+  but allowed to proceed.
+
+  @happy
+  Scenario: DynamoDB allows requests through in audit mode
+    Given IAM auth was set for "dynamodb" with mode "audit"
+    When I list DynamoDB tables
+    Then the command will succeed
+    And IAM auth was cleaned up for "dynamodb"
+
+  @happy
+  Scenario: SSM allows requests through in audit mode
+    Given IAM auth was set for "ssm" with mode "audit"
+    When I describe SSM parameters
+    Then the command will succeed
+    And IAM auth was cleaned up for "ssm"

--- a/lang/specification/core/features/iam_auth/cognito_permissions.feature
+++ b/lang/specification/core/features/iam_auth/cognito_permissions.feature
@@ -1,0 +1,91 @@
+Feature: Cognito IAM Authorization
+
+  @iam_auth @cognito @denied
+  Scenario Outline: Cognito <operation> is denied in enforce mode
+    Given IAM auth was set for "cognito-idp" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "cognito-idp" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "cognito-idp"
+
+    Examples:
+      | operation                  |
+      | list-user-pools            |
+      | create-user-pool           |
+      | delete-user-pool           |
+      | describe-user-pool         |
+      | update-user-pool           |
+      | create-user-pool-client    |
+      | delete-user-pool-client    |
+      | describe-user-pool-client  |
+      | list-user-pool-clients     |
+      | admin-get-user             |
+      | admin-create-user          |
+      | admin-delete-user          |
+      | list-users                 |
+      | sign-up                    |
+      | confirm-sign-up            |
+      | initiate-auth              |
+      | forgot-password            |
+      | confirm-forgot-password    |
+      | change-password            |
+      | global-sign-out            |
+
+  @iam_auth @cognito @audit
+  Scenario Outline: Cognito <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "cognito-idp" with mode "audit" and identity "lws-test-no-perms"
+    When I call "cognito-idp" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "cognito-idp"
+
+    Examples:
+      | operation                  |
+      | list-user-pools            |
+      | create-user-pool           |
+      | delete-user-pool           |
+      | describe-user-pool         |
+      | update-user-pool           |
+      | create-user-pool-client    |
+      | delete-user-pool-client    |
+      | describe-user-pool-client  |
+      | list-user-pool-clients     |
+      | admin-get-user             |
+      | admin-create-user          |
+      | admin-delete-user          |
+      | list-users                 |
+      | sign-up                    |
+      | confirm-sign-up            |
+      | initiate-auth              |
+      | forgot-password            |
+      | confirm-forgot-password    |
+      | change-password            |
+      | global-sign-out            |
+
+  @iam_auth @cognito @pass
+  Scenario Outline: Cognito <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "cognito-idp" with mode "enforce" and identity "lws-test-full-access"
+    When I call "cognito-idp" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "cognito-idp"
+
+    Examples:
+      | operation                  |
+      | list-user-pools            |
+      | create-user-pool           |
+      | delete-user-pool           |
+      | describe-user-pool         |
+      | update-user-pool           |
+      | create-user-pool-client    |
+      | delete-user-pool-client    |
+      | describe-user-pool-client  |
+      | list-user-pool-clients     |
+      | admin-get-user             |
+      | admin-create-user          |
+      | admin-delete-user          |
+      | list-users                 |
+      | sign-up                    |
+      | confirm-sign-up            |
+      | initiate-auth              |
+      | forgot-password            |
+      | confirm-forgot-password    |
+      | change-password            |
+      | global-sign-out            |

--- a/lang/specification/core/features/iam_auth/dynamodb_permissions.feature
+++ b/lang/specification/core/features/iam_auth/dynamodb_permissions.feature
@@ -1,0 +1,94 @@
+Feature: DynamoDB IAM Authorization
+
+  @iam_auth @dynamodb @denied
+  Scenario Outline: DynamoDB <operation> is denied in enforce mode
+    Given IAM auth was set for "dynamodb" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "dynamodb" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "dynamodb"
+
+    Examples:
+      | operation                    |
+      | list-tables                  |
+      | create-table                 |
+      | delete-table                 |
+      | describe-table               |
+      | update-table                 |
+      | describe-time-to-live        |
+      | update-time-to-live          |
+      | describe-continuous-backups  |
+      | get-item                     |
+      | put-item                     |
+      | delete-item                  |
+      | update-item                  |
+      | query                        |
+      | scan                         |
+      | batch-get-item               |
+      | batch-write-item             |
+      | transact-get-items           |
+      | transact-write-items         |
+      | list-tags-of-resource        |
+      | tag-resource                 |
+      | untag-resource               |
+
+  @iam_auth @dynamodb @audit
+  Scenario Outline: DynamoDB <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "dynamodb" with mode "audit" and identity "lws-test-no-perms"
+    When I call "dynamodb" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "dynamodb"
+
+    Examples:
+      | operation                    |
+      | list-tables                  |
+      | create-table                 |
+      | delete-table                 |
+      | describe-table               |
+      | update-table                 |
+      | describe-time-to-live        |
+      | update-time-to-live          |
+      | describe-continuous-backups  |
+      | get-item                     |
+      | put-item                     |
+      | delete-item                  |
+      | update-item                  |
+      | query                        |
+      | scan                         |
+      | batch-get-item               |
+      | batch-write-item             |
+      | transact-get-items           |
+      | transact-write-items         |
+      | list-tags-of-resource        |
+      | tag-resource                 |
+      | untag-resource               |
+
+  @iam_auth @dynamodb @pass
+  Scenario Outline: DynamoDB <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "dynamodb" with mode "enforce" and identity "lws-test-full-access"
+    When I call "dynamodb" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "dynamodb"
+
+    Examples:
+      | operation                    |
+      | list-tables                  |
+      | create-table                 |
+      | delete-table                 |
+      | describe-table               |
+      | update-table                 |
+      | describe-time-to-live        |
+      | update-time-to-live          |
+      | describe-continuous-backups  |
+      | get-item                     |
+      | put-item                     |
+      | delete-item                  |
+      | update-item                  |
+      | query                        |
+      | scan                         |
+      | batch-get-item               |
+      | batch-write-item             |
+      | transact-get-items           |
+      | transact-write-items         |
+      | list-tags-of-resource        |
+      | tag-resource                 |
+      | untag-resource               |

--- a/lang/specification/core/features/iam_auth/enable_disable.feature
+++ b/lang/specification/core/features/iam_auth/enable_disable.feature
@@ -1,0 +1,20 @@
+@iam_auth @enable_disable @dataplane
+Feature: IAM auth enable and disable
+
+  Enabling IAM auth in enforce mode denies requests from unknown identities.
+  Disabling returns to pass-through behaviour.
+
+  @error
+  Scenario: Enabling IAM auth in enforce mode denies DynamoDB requests
+    Given IAM auth was enabled for "dynamodb" with mode "enforce"
+    When I list DynamoDB tables
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "dynamodb"
+
+  @happy
+  Scenario: Disabling IAM auth allows DynamoDB requests through
+    Given IAM auth was enabled for "dynamodb" with mode "enforce"
+    And IAM auth was disabled for "dynamodb"
+    When I list DynamoDB tables
+    Then the command will succeed
+    And IAM auth was cleaned up for "dynamodb"

--- a/lang/specification/core/features/iam_auth/enforce_mode.feature
+++ b/lang/specification/core/features/iam_auth/enforce_mode.feature
@@ -1,0 +1,26 @@
+@iam_auth @enforce_mode @dataplane
+Feature: IAM auth enforce mode denies unauthorized requests
+
+  When enforce mode is active, requests from unknown identities receive
+  an AccessDeniedException with status 403.
+
+  @error
+  Scenario: DynamoDB returns JSON access denied error when enforce mode is active
+    Given IAM auth was enabled for "dynamodb" with mode "enforce"
+    When I list DynamoDB tables
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "dynamodb"
+
+  @error
+  Scenario: SSM returns JSON access denied error when enforce mode is active
+    Given IAM auth was enabled for "ssm" with mode "enforce"
+    When I describe SSM parameters
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "ssm"
+
+  @error
+  Scenario: Secrets Manager returns JSON access denied error when enforce mode is active
+    Given IAM auth was enabled for "secretsmanager" with mode "enforce"
+    When I list Secrets Manager secrets
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "secretsmanager"

--- a/lang/specification/core/features/iam_auth/eventbridge_permissions.feature
+++ b/lang/specification/core/features/iam_auth/eventbridge_permissions.feature
@@ -1,0 +1,82 @@
+Feature: EventBridge IAM Authorization
+
+  @iam_auth @events @denied
+  Scenario Outline: EventBridge <operation> is denied in enforce mode
+    Given IAM auth was set for "events" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "events" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "events"
+
+    Examples:
+      | operation               |
+      | list-rules              |
+      | list-event-buses        |
+      | describe-event-bus      |
+      | create-event-bus        |
+      | delete-event-bus        |
+      | put-rule                |
+      | delete-rule             |
+      | describe-rule           |
+      | put-targets             |
+      | remove-targets          |
+      | list-targets-by-rule    |
+      | enable-rule             |
+      | disable-rule            |
+      | put-events              |
+      | list-tags-for-resource  |
+      | tag-resource            |
+      | untag-resource          |
+
+  @iam_auth @events @audit
+  Scenario Outline: EventBridge <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "events" with mode "audit" and identity "lws-test-no-perms"
+    When I call "events" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "events"
+
+    Examples:
+      | operation               |
+      | list-rules              |
+      | list-event-buses        |
+      | describe-event-bus      |
+      | create-event-bus        |
+      | delete-event-bus        |
+      | put-rule                |
+      | delete-rule             |
+      | describe-rule           |
+      | put-targets             |
+      | remove-targets          |
+      | list-targets-by-rule    |
+      | enable-rule             |
+      | disable-rule            |
+      | put-events              |
+      | list-tags-for-resource  |
+      | tag-resource            |
+      | untag-resource          |
+
+  @iam_auth @events @pass
+  Scenario Outline: EventBridge <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "events" with mode "enforce" and identity "lws-test-full-access"
+    When I call "events" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "events"
+
+    Examples:
+      | operation               |
+      | list-rules              |
+      | list-event-buses        |
+      | describe-event-bus      |
+      | create-event-bus        |
+      | delete-event-bus        |
+      | put-rule                |
+      | delete-rule             |
+      | describe-rule           |
+      | put-targets             |
+      | remove-targets          |
+      | list-targets-by-rule    |
+      | enable-rule             |
+      | disable-rule            |
+      | put-events              |
+      | list-tags-for-resource  |
+      | tag-resource            |
+      | untag-resource          |

--- a/lang/specification/core/features/iam_auth/s3_permissions.feature
+++ b/lang/specification/core/features/iam_auth/s3_permissions.feature
@@ -1,0 +1,112 @@
+Feature: S3 IAM Authorization
+
+  @iam_auth @s3 @denied
+  Scenario Outline: S3 <operation> is denied in enforce mode
+    Given IAM auth was set for "s3" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "s3" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "s3"
+
+    Examples:
+      | operation                              |
+      | list-buckets                           |
+      | create-bucket                          |
+      | delete-bucket                          |
+      | head-bucket                            |
+      | list-objects-v2                        |
+      | get-bucket-location                    |
+      | get-bucket-tagging                     |
+      | put-bucket-tagging                     |
+      | delete-bucket-tagging                  |
+      | get-bucket-policy                      |
+      | put-bucket-policy                      |
+      | get-bucket-notification-configuration |
+      | put-bucket-notification-configuration |
+      | get-bucket-website                     |
+      | put-bucket-website                     |
+      | delete-bucket-website                  |
+      | get-object                             |
+      | put-object                             |
+      | delete-object                          |
+      | head-object                            |
+      | copy-object                            |
+      | delete-objects                         |
+      | create-multipart-upload                |
+      | upload-part                            |
+      | complete-multipart-upload              |
+      | abort-multipart-upload                 |
+      | list-parts                             |
+
+  @iam_auth @s3 @audit
+  Scenario Outline: S3 <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "s3" with mode "audit" and identity "lws-test-no-perms"
+    When I call "s3" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "s3"
+
+    Examples:
+      | operation                              |
+      | list-buckets                           |
+      | create-bucket                          |
+      | delete-bucket                          |
+      | head-bucket                            |
+      | list-objects-v2                        |
+      | get-bucket-location                    |
+      | get-bucket-tagging                     |
+      | put-bucket-tagging                     |
+      | delete-bucket-tagging                  |
+      | get-bucket-policy                      |
+      | put-bucket-policy                      |
+      | get-bucket-notification-configuration |
+      | put-bucket-notification-configuration |
+      | get-bucket-website                     |
+      | put-bucket-website                     |
+      | delete-bucket-website                  |
+      | get-object                             |
+      | put-object                             |
+      | delete-object                          |
+      | head-object                            |
+      | copy-object                            |
+      | delete-objects                         |
+      | create-multipart-upload                |
+      | upload-part                            |
+      | complete-multipart-upload              |
+      | abort-multipart-upload                 |
+      | list-parts                             |
+
+  @iam_auth @s3 @pass
+  Scenario Outline: S3 <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "s3" with mode "enforce" and identity "lws-test-full-access"
+    When I call "s3" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "s3"
+
+    Examples:
+      | operation                              |
+      | list-buckets                           |
+      | create-bucket                          |
+      | delete-bucket                          |
+      | head-bucket                            |
+      | list-objects-v2                        |
+      | get-bucket-location                    |
+      | get-bucket-tagging                     |
+      | put-bucket-tagging                     |
+      | delete-bucket-tagging                  |
+      | get-bucket-policy                      |
+      | put-bucket-policy                      |
+      | get-bucket-notification-configuration |
+      | put-bucket-notification-configuration |
+      | get-bucket-website                     |
+      | put-bucket-website                     |
+      | delete-bucket-website                  |
+      | get-object                             |
+      | put-object                             |
+      | delete-object                          |
+      | head-object                            |
+      | copy-object                            |
+      | delete-objects                         |
+      | create-multipart-upload                |
+      | upload-part                            |
+      | complete-multipart-upload              |
+      | abort-multipart-upload                 |
+      | list-parts                             |

--- a/lang/specification/core/features/iam_auth/secretsmanager_permissions.feature
+++ b/lang/specification/core/features/iam_auth/secretsmanager_permissions.feature
@@ -1,0 +1,67 @@
+Feature: Secrets Manager IAM Authorization
+
+  @iam_auth @secretsmanager @denied
+  Scenario Outline: Secrets Manager <operation> is denied in enforce mode
+    Given IAM auth was set for "secretsmanager" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "secretsmanager" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "secretsmanager"
+
+    Examples:
+      | operation                   |
+      | list-secrets                |
+      | create-secret               |
+      | get-secret-value            |
+      | put-secret-value            |
+      | describe-secret             |
+      | update-secret               |
+      | delete-secret               |
+      | restore-secret              |
+      | list-secret-version-ids     |
+      | get-resource-policy         |
+      | tag-resource                |
+      | untag-resource              |
+
+  @iam_auth @secretsmanager @audit
+  Scenario Outline: Secrets Manager <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "secretsmanager" with mode "audit" and identity "lws-test-no-perms"
+    When I call "secretsmanager" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "secretsmanager"
+
+    Examples:
+      | operation                   |
+      | list-secrets                |
+      | create-secret               |
+      | get-secret-value            |
+      | put-secret-value            |
+      | describe-secret             |
+      | update-secret               |
+      | delete-secret               |
+      | restore-secret              |
+      | list-secret-version-ids     |
+      | get-resource-policy         |
+      | tag-resource                |
+      | untag-resource              |
+
+  @iam_auth @secretsmanager @pass
+  Scenario Outline: Secrets Manager <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "secretsmanager" with mode "enforce" and identity "lws-test-full-access"
+    When I call "secretsmanager" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "secretsmanager"
+
+    Examples:
+      | operation                   |
+      | list-secrets                |
+      | create-secret               |
+      | get-secret-value            |
+      | put-secret-value            |
+      | describe-secret             |
+      | update-secret               |
+      | delete-secret               |
+      | restore-secret              |
+      | list-secret-version-ids     |
+      | get-resource-policy         |
+      | tag-resource                |
+      | untag-resource              |

--- a/lang/specification/core/features/iam_auth/set_mode.feature
+++ b/lang/specification/core/features/iam_auth/set_mode.feature
@@ -1,0 +1,18 @@
+@iam_auth @set_mode @dataplane
+Feature: IAM auth mode setting
+
+  The mode can be changed between enforce, audit, and disabled at runtime.
+
+  @error
+  Scenario: Enforce mode denies SSM requests from unknown identities
+    Given IAM auth was set for "ssm" with mode "enforce"
+    When I describe SSM parameters
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "ssm"
+
+  @happy
+  Scenario: Audit mode allows requests through despite unknown identity
+    Given IAM auth was set for "dynamodb" with mode "audit"
+    When I list DynamoDB tables
+    Then the command will succeed
+    And IAM auth was cleaned up for "dynamodb"

--- a/lang/specification/core/features/iam_auth/sns_permissions.feature
+++ b/lang/specification/core/features/iam_auth/sns_permissions.feature
@@ -1,0 +1,79 @@
+Feature: SNS IAM Authorization
+
+  @iam_auth @sns @denied
+  Scenario Outline: SNS <operation> is denied in enforce mode
+    Given IAM auth was set for "sns" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "sns" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "sns"
+
+    Examples:
+      | operation                    |
+      | list-topics                  |
+      | list-subscriptions           |
+      | list-subscriptions-by-topic  |
+      | create-topic                 |
+      | delete-topic                 |
+      | publish                      |
+      | subscribe                    |
+      | unsubscribe                  |
+      | get-topic-attributes         |
+      | set-topic-attributes         |
+      | get-subscription-attributes  |
+      | set-subscription-attributes  |
+      | confirm-subscription         |
+      | list-tags-for-resource       |
+      | tag-resource                 |
+      | untag-resource               |
+
+  @iam_auth @sns @audit
+  Scenario Outline: SNS <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "sns" with mode "audit" and identity "lws-test-no-perms"
+    When I call "sns" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "sns"
+
+    Examples:
+      | operation                    |
+      | list-topics                  |
+      | list-subscriptions           |
+      | list-subscriptions-by-topic  |
+      | create-topic                 |
+      | delete-topic                 |
+      | publish                      |
+      | subscribe                    |
+      | unsubscribe                  |
+      | get-topic-attributes         |
+      | set-topic-attributes         |
+      | get-subscription-attributes  |
+      | set-subscription-attributes  |
+      | confirm-subscription         |
+      | list-tags-for-resource       |
+      | tag-resource                 |
+      | untag-resource               |
+
+  @iam_auth @sns @pass
+  Scenario Outline: SNS <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "sns" with mode "enforce" and identity "lws-test-full-access"
+    When I call "sns" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "sns"
+
+    Examples:
+      | operation                    |
+      | list-topics                  |
+      | list-subscriptions           |
+      | list-subscriptions-by-topic  |
+      | create-topic                 |
+      | delete-topic                 |
+      | publish                      |
+      | subscribe                    |
+      | unsubscribe                  |
+      | get-topic-attributes         |
+      | set-topic-attributes         |
+      | get-subscription-attributes  |
+      | set-subscription-attributes  |
+      | confirm-subscription         |
+      | list-tags-for-resource       |
+      | tag-resource                 |
+      | untag-resource               |

--- a/lang/specification/core/features/iam_auth/sqs_permissions.feature
+++ b/lang/specification/core/features/iam_auth/sqs_permissions.feature
@@ -1,0 +1,85 @@
+Feature: SQS IAM Authorization
+
+  @iam_auth @sqs @denied
+  Scenario Outline: SQS <operation> is denied in enforce mode
+    Given IAM auth was set for "sqs" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "sqs" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "sqs"
+
+    Examples:
+      | operation                          |
+      | list-queues                        |
+      | create-queue                       |
+      | delete-queue                       |
+      | get-queue-url                      |
+      | get-queue-attributes               |
+      | set-queue-attributes               |
+      | purge-queue                        |
+      | list-queue-tags                    |
+      | tag-queue                          |
+      | untag-queue                        |
+      | send-message                       |
+      | send-message-batch                 |
+      | receive-message                    |
+      | delete-message                     |
+      | delete-message-batch               |
+      | change-message-visibility          |
+      | change-message-visibility-batch    |
+      | list-dead-letter-source-queues     |
+
+  @iam_auth @sqs @audit
+  Scenario Outline: SQS <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "sqs" with mode "audit" and identity "lws-test-no-perms"
+    When I call "sqs" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "sqs"
+
+    Examples:
+      | operation                          |
+      | list-queues                        |
+      | create-queue                       |
+      | delete-queue                       |
+      | get-queue-url                      |
+      | get-queue-attributes               |
+      | set-queue-attributes               |
+      | purge-queue                        |
+      | list-queue-tags                    |
+      | tag-queue                          |
+      | untag-queue                        |
+      | send-message                       |
+      | send-message-batch                 |
+      | receive-message                    |
+      | delete-message                     |
+      | delete-message-batch               |
+      | change-message-visibility          |
+      | change-message-visibility-batch    |
+      | list-dead-letter-source-queues     |
+
+  @iam_auth @sqs @pass
+  Scenario Outline: SQS <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "sqs" with mode "enforce" and identity "lws-test-full-access"
+    When I call "sqs" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "sqs"
+
+    Examples:
+      | operation                          |
+      | list-queues                        |
+      | create-queue                       |
+      | delete-queue                       |
+      | get-queue-url                      |
+      | get-queue-attributes               |
+      | set-queue-attributes               |
+      | purge-queue                        |
+      | list-queue-tags                    |
+      | tag-queue                          |
+      | untag-queue                        |
+      | send-message                       |
+      | send-message-batch                 |
+      | receive-message                    |
+      | delete-message                     |
+      | delete-message-batch               |
+      | change-message-visibility          |
+      | change-message-visibility-batch    |
+      | list-dead-letter-source-queues     |

--- a/lang/specification/core/features/iam_auth/ssm_permissions.feature
+++ b/lang/specification/core/features/iam_auth/ssm_permissions.feature
@@ -1,0 +1,61 @@
+Feature: SSM IAM Authorization
+
+  @iam_auth @ssm @denied
+  Scenario Outline: SSM <operation> is denied in enforce mode
+    Given IAM auth was set for "ssm" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "ssm" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "ssm"
+
+    Examples:
+      | operation                   |
+      | describe-parameters         |
+      | get-parameter               |
+      | get-parameters              |
+      | get-parameters-by-path      |
+      | put-parameter               |
+      | delete-parameter            |
+      | delete-parameters           |
+      | add-tags-to-resource        |
+      | remove-tags-from-resource   |
+      | list-tags-for-resource      |
+
+  @iam_auth @ssm @audit
+  Scenario Outline: SSM <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "ssm" with mode "audit" and identity "lws-test-no-perms"
+    When I call "ssm" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "ssm"
+
+    Examples:
+      | operation                   |
+      | describe-parameters         |
+      | get-parameter               |
+      | get-parameters              |
+      | get-parameters-by-path      |
+      | put-parameter               |
+      | delete-parameter            |
+      | delete-parameters           |
+      | add-tags-to-resource        |
+      | remove-tags-from-resource   |
+      | list-tags-for-resource      |
+
+  @iam_auth @ssm @pass
+  Scenario Outline: SSM <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "ssm" with mode "enforce" and identity "lws-test-full-access"
+    When I call "ssm" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "ssm"
+
+    Examples:
+      | operation                   |
+      | describe-parameters         |
+      | get-parameter               |
+      | get-parameters              |
+      | get-parameters-by-path      |
+      | put-parameter               |
+      | delete-parameter            |
+      | delete-parameters           |
+      | add-tags-to-resource        |
+      | remove-tags-from-resource   |
+      | list-tags-for-resource      |

--- a/lang/specification/core/features/iam_auth/stepfunctions_permissions.feature
+++ b/lang/specification/core/features/iam_auth/stepfunctions_permissions.feature
@@ -1,0 +1,79 @@
+Feature: Step Functions IAM Authorization
+
+  @iam_auth @stepfunctions @denied
+  Scenario Outline: Step Functions <operation> is denied in enforce mode
+    Given IAM auth was set for "stepfunctions" with mode "enforce" and identity "lws-test-no-perms"
+    When I call "stepfunctions" "<operation>"
+    Then the output will contain an IAM access denied error
+    And IAM auth was cleaned up for "stepfunctions"
+
+    Examples:
+      | operation                          |
+      | list-state-machines                |
+      | create-state-machine               |
+      | delete-state-machine               |
+      | describe-state-machine             |
+      | update-state-machine               |
+      | validate-state-machine-definition  |
+      | list-state-machine-versions        |
+      | start-execution                    |
+      | start-sync-execution               |
+      | stop-execution                     |
+      | describe-execution                 |
+      | list-executions                    |
+      | get-execution-history              |
+      | list-tags-for-resource             |
+      | tag-resource                       |
+      | untag-resource                     |
+
+  @iam_auth @stepfunctions @audit
+  Scenario Outline: Step Functions <operation> passes through in audit mode with a warning
+    Given IAM auth was set for "stepfunctions" with mode "audit" and identity "lws-test-no-perms"
+    When I call "stepfunctions" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "stepfunctions"
+
+    Examples:
+      | operation                          |
+      | list-state-machines                |
+      | create-state-machine               |
+      | delete-state-machine               |
+      | describe-state-machine             |
+      | update-state-machine               |
+      | validate-state-machine-definition  |
+      | list-state-machine-versions        |
+      | start-execution                    |
+      | start-sync-execution               |
+      | stop-execution                     |
+      | describe-execution                 |
+      | list-executions                    |
+      | get-execution-history              |
+      | list-tags-for-resource             |
+      | tag-resource                       |
+      | untag-resource                     |
+
+  @iam_auth @stepfunctions @pass
+  Scenario Outline: Step Functions <operation> passes in enforce mode with permissions
+    Given IAM auth was set for "stepfunctions" with mode "enforce" and identity "lws-test-full-access"
+    When I call "stepfunctions" "<operation>"
+    Then the output will not contain an IAM access denied error
+    And IAM auth was cleaned up for "stepfunctions"
+
+    Examples:
+      | operation                          |
+      | list-state-machines                |
+      | create-state-machine               |
+      | delete-state-machine               |
+      | describe-state-machine             |
+      | update-state-machine               |
+      | validate-state-machine-definition  |
+      | list-state-machine-versions        |
+      | start-execution                    |
+      | start-sync-execution               |
+      | stop-execution                     |
+      | describe-execution                 |
+      | list-executions                    |
+      | get-execution-history              |
+      | list-tags-for-resource             |
+      | tag-resource                       |
+      | untag-resource                     |

--- a/lang/specification/core/features/init/init.feature
+++ b/lang/specification/core/features/init/init.feature
@@ -1,0 +1,39 @@
+@init @controlplane
+Feature: LWS init scaffolds agent configuration
+
+  The lws init command writes a CLAUDE.md snippet and custom slash
+  commands into a project directory so coding agents understand how
+  to use lws.
+
+  @happy
+  Scenario: Init creates CLAUDE.md in a new project
+    Given an empty project directory was created
+    When I run lws init in the project directory
+    Then the command will succeed
+    And CLAUDE.md will exist in the project directory
+    And CLAUDE.md will contain "Local Web Services"
+
+  @happy
+  Scenario: Init creates slash commands
+    Given an empty project directory was created
+    When I run lws init in the project directory
+    Then the command will succeed
+    And ".claude/commands/lws/fake.md" will exist in the project directory
+    And ".claude/commands/lws/chaos.md" will exist in the project directory
+
+  @happy
+  Scenario: Init appends to existing CLAUDE.md
+    Given an empty project directory was created
+    And CLAUDE.md with content "# My Project" was created in the project directory
+    When I run lws init in the project directory
+    Then the command will succeed
+    And CLAUDE.md will contain "# My Project"
+    And CLAUDE.md will contain "Local Web Services"
+
+  @happy
+  Scenario: Init is idempotent
+    Given an empty project directory was created
+    And lws init was already run in the project directory
+    When I run lws init in the project directory
+    Then the command will succeed
+    And CLAUDE.md will contain exactly 1 occurrence of "LWS:START"

--- a/lang/specification/core/features/lambda_/add_permission.feature
+++ b/lang/specification/core/features/lambda_/add_permission.feature
@@ -1,0 +1,9 @@
+@lambda @add_permission @controlplane @requires_docker
+Feature: Lambda AddPermission
+
+  @happy
+  Scenario: Add a permission to a Lambda function
+    Given a function "e2e-addperm-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I add permission "s3-invoke" to function "e2e-addperm-fn" with action "lambda:InvokeFunction" and principal "s3.amazonaws.com"
+    Then the command will succeed
+    And function "e2e-addperm-fn" will have permission "s3-invoke" in its policy

--- a/lang/specification/core/features/lambda_/create_event_source_mapping.feature
+++ b/lang/specification/core/features/lambda_/create_event_source_mapping.feature
@@ -1,0 +1,9 @@
+@lambda @create_event_source_mapping @controlplane
+Feature: Lambda CreateEventSourceMapping
+
+  @happy
+  Scenario: Create an event source mapping and verify it appears in list
+    When I create event source mapping for function "e2e-esm-function" with source "arn:aws:sqs:us-east-1:000000000000:e2e-esm-queue" and batch size "5"
+    Then the command will succeed
+    And the output will contain a UUID
+    And the event source mapping will appear in the list

--- a/lang/specification/core/features/lambda_/create_function.feature
+++ b/lang/specification/core/features/lambda_/create_function.feature
@@ -1,0 +1,8 @@
+@lambda @create_function @controlplane @requires_docker
+Feature: Lambda CreateFunction
+
+  @happy
+  Scenario: Create a new Lambda function
+    When I create function "e2e-create-fn" with runtime "python3.12" and handler "handler.handler"
+    Then the command will succeed
+    And function "e2e-create-fn" will appear in list-functions

--- a/lang/specification/core/features/lambda_/delete_event_source_mapping.feature
+++ b/lang/specification/core/features/lambda_/delete_event_source_mapping.feature
@@ -1,0 +1,9 @@
+@lambda @delete_event_source_mapping @controlplane
+Feature: Lambda DeleteEventSourceMapping
+
+  @happy
+  Scenario: Delete an event source mapping
+    Given an event source mapping was created for function "e2e-del-esm-fn" with source "arn:aws:sqs:us-east-1:000000000000:e2e-del-esm-queue"
+    When I delete the event source mapping
+    Then the command will succeed
+    And the event source mapping will not appear in the list

--- a/lang/specification/core/features/lambda_/delete_function.feature
+++ b/lang/specification/core/features/lambda_/delete_function.feature
@@ -1,0 +1,9 @@
+@lambda @delete_function @controlplane @requires_docker
+Feature: Lambda DeleteFunction
+
+  @happy
+  Scenario: Delete an existing Lambda function
+    Given a function "e2e-del-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I delete function "e2e-del-fn"
+    Then the command will succeed
+    And function "e2e-del-fn" will not appear in list-functions

--- a/lang/specification/core/features/lambda_/get_event_source_mapping.feature
+++ b/lang/specification/core/features/lambda_/get_event_source_mapping.feature
@@ -1,0 +1,10 @@
+@lambda @get_event_source_mapping @controlplane @requires_docker
+Feature: Lambda GetEventSourceMapping
+
+  @happy
+  Scenario: Get an event source mapping by UUID
+    Given a function "e2e-getesm-fn" was created with runtime "python3.12" and handler "handler.handler"
+    And an event source mapping was created for function "e2e-getesm-fn" with source "arn:aws:sqs:us-east-1:000000000000:e2e-getesm-q"
+    When I get the event source mapping
+    Then the command will succeed
+    And the output will contain a UUID

--- a/lang/specification/core/features/lambda_/get_function.feature
+++ b/lang/specification/core/features/lambda_/get_function.feature
@@ -1,0 +1,8 @@
+@lambda @get_function @controlplane @requires_docker
+Feature: Lambda GetFunction
+
+  @happy
+  Scenario: Get an existing Lambda function
+    Given a function "e2e-get-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I get function "e2e-get-fn"
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/get_policy.feature
+++ b/lang/specification/core/features/lambda_/get_policy.feature
@@ -1,0 +1,8 @@
+@lambda @get_policy @controlplane @requires_docker
+Feature: Lambda GetPolicy
+
+  @happy
+  Scenario: Get a Lambda function policy
+    Given a function "e2e-getpol-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I get the policy of function "e2e-getpol-fn"
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/invoke.feature
+++ b/lang/specification/core/features/lambda_/invoke.feature
@@ -1,0 +1,8 @@
+@lambda @invoke @error @dataplane
+Feature: Lambda Invoke
+
+  @error
+  Scenario: Invoke a non-existent function returns an error message
+    When I invoke function "e2e-nonexistent-fn"
+    Then the command will succeed
+    And the output will contain an error message

--- a/lang/specification/core/features/lambda_/lambda_s3_integration.feature
+++ b/lang/specification/core/features/lambda_/lambda_s3_integration.feature
@@ -1,0 +1,11 @@
+@lambda @lambda_s3_integration @dataplane @requires_docker
+Feature: Lambda S3 Integration
+
+  @happy
+  Scenario: Lambda function writes to S3 using path-style addressing
+    Given an S3 bucket "e2e-lambda-s3-bucket" was created
+    And a Lambda function "e2e-s3-writer" was created with S3 handler code
+    When I invoke function "e2e-s3-writer" with event {"bucket": "e2e-lambda-s3-bucket", "key": "e2e-lambda-output.txt", "body": "hello from lambda"}
+    Then the command will succeed
+    And the invoke output will have status code 200
+    And S3 object "e2e-lambda-output.txt" in bucket "e2e-lambda-s3-bucket" will contain "hello from lambda"

--- a/lang/specification/core/features/lambda_/lambda_s3_nodejs_integration.feature
+++ b/lang/specification/core/features/lambda_/lambda_s3_nodejs_integration.feature
@@ -1,0 +1,11 @@
+@lambda @lambda_s3_nodejs_integration @dataplane @requires_docker @requires_nodejs_image
+Feature: Lambda S3 Node.js Integration
+
+  @happy
+  Scenario: Node.js Lambda function writes to S3 without forcePathStyle
+    Given an S3 bucket "e2e-nodejs-s3-bucket" was created
+    And a Node.js Lambda function "e2e-nodejs-s3-writer" was created with S3 handler code
+    When I invoke function "e2e-nodejs-s3-writer" with event {"bucket": "e2e-nodejs-s3-bucket", "key": "e2e-nodejs-output.txt", "body": "hello from nodejs lambda"}
+    Then the command will succeed
+    And the invoke output will have status code 200
+    And S3 object "e2e-nodejs-output.txt" in bucket "e2e-nodejs-s3-bucket" will contain "hello from nodejs lambda"

--- a/lang/specification/core/features/lambda_/list_event_source_mappings.feature
+++ b/lang/specification/core/features/lambda_/list_event_source_mappings.feature
@@ -1,0 +1,7 @@
+@lambda @list_event_source_mappings @controlplane
+Feature: Lambda ListEventSourceMappings
+
+  @happy
+  Scenario: List event source mappings
+    When I list event source mappings
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/list_functions.feature
+++ b/lang/specification/core/features/lambda_/list_functions.feature
@@ -1,0 +1,7 @@
+@lambda @list_functions @controlplane
+Feature: Lambda ListFunctions
+
+  @happy
+  Scenario: List Lambda functions
+    When I list functions
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/list_tags.feature
+++ b/lang/specification/core/features/lambda_/list_tags.feature
@@ -1,0 +1,9 @@
+@lambda @list_tags @controlplane @requires_docker
+Feature: Lambda ListTags
+
+  @happy
+  Scenario: List tags for a Lambda function
+    Given a function "e2e-listtags-fn" was created with runtime "python3.12" and handler "handler.handler"
+    And function "e2e-listtags-fn" was tagged with key "env" and value "prod"
+    When I list tags for function "e2e-listtags-fn"
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/remove_permission.feature
+++ b/lang/specification/core/features/lambda_/remove_permission.feature
@@ -1,0 +1,10 @@
+@lambda @remove_permission @controlplane @requires_docker
+Feature: Lambda RemovePermission
+
+  @happy
+  Scenario: Remove a permission from a Lambda function
+    Given a function "e2e-rmperm-fn" was created with runtime "python3.12" and handler "handler.handler"
+    And permission "s3-invoke" was added to function "e2e-rmperm-fn"
+    When I remove permission "s3-invoke" from function "e2e-rmperm-fn"
+    Then the command will succeed
+    And function "e2e-rmperm-fn" will not have permission "s3-invoke" in its policy

--- a/lang/specification/core/features/lambda_/tag_resource.feature
+++ b/lang/specification/core/features/lambda_/tag_resource.feature
@@ -1,0 +1,9 @@
+@lambda @tag_resource @controlplane @requires_docker
+Feature: Lambda TagResource
+
+  @happy
+  Scenario: Tag a Lambda function
+    Given a function "e2e-tag-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I tag function "e2e-tag-fn" with key "env" and value "test"
+    Then the command will succeed
+    And function "e2e-tag-fn" will have tag "env" with value "test"

--- a/lang/specification/core/features/lambda_/untag_resource.feature
+++ b/lang/specification/core/features/lambda_/untag_resource.feature
@@ -1,0 +1,10 @@
+@lambda @untag_resource @controlplane @requires_docker
+Feature: Lambda UntagResource
+
+  @happy
+  Scenario: Untag a Lambda function
+    Given a function "e2e-untag-fn" was created with runtime "python3.12" and handler "handler.handler"
+    And function "e2e-untag-fn" was tagged with key "env" and value "test"
+    When I untag function "e2e-untag-fn" removing key "env"
+    Then the command will succeed
+    And function "e2e-untag-fn" will not have tag "env"

--- a/lang/specification/core/features/lambda_/update_function_code.feature
+++ b/lang/specification/core/features/lambda_/update_function_code.feature
@@ -1,0 +1,8 @@
+@lambda @update_function_code @controlplane @requires_docker
+Feature: Lambda UpdateFunctionCode
+
+  @happy
+  Scenario: Update function code
+    Given a function "e2e-upd-code-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I update function code for "e2e-upd-code-fn"
+    Then the command will succeed

--- a/lang/specification/core/features/lambda_/update_function_configuration.feature
+++ b/lang/specification/core/features/lambda_/update_function_configuration.feature
@@ -1,0 +1,9 @@
+@lambda @update_function_configuration @controlplane @requires_docker
+Feature: Lambda UpdateFunctionConfiguration
+
+  @happy
+  Scenario: Update function configuration
+    Given a function "e2e-upd-cfg-fn" was created with runtime "python3.12" and handler "handler.handler"
+    When I update function configuration for "e2e-upd-cfg-fn" with timeout "60"
+    Then the command will succeed
+    And function "e2e-upd-cfg-fn" will have timeout 60

--- a/lang/specification/core/features/lambda_function_url/create_function_url_config.feature
+++ b/lang/specification/core/features/lambda_function_url/create_function_url_config.feature
@@ -1,0 +1,25 @@
+@lambda @create_function_url_config @controlplane
+Feature: Lambda CreateFunctionUrlConfig
+
+  @happy
+  Scenario: Create a Function URL config for a function
+    Given a Lambda function "e2e-furl-create-fn" was created
+    When I create a function URL config for "e2e-furl-create-fn"
+    Then the command will succeed
+    And the output will contain function URL for "e2e-furl-create-fn"
+
+  @happy
+  Scenario: Get a Function URL config after creation
+    Given a Lambda function "e2e-furl-get-fn" was created
+    And a function URL config for "e2e-furl-get-fn" was created
+    When I get the function URL config for "e2e-furl-get-fn"
+    Then the command will succeed
+    And the output will contain function name "e2e-furl-get-fn"
+
+  @happy
+  Scenario: Delete a Function URL config
+    Given a Lambda function "e2e-furl-del-fn" was created
+    And a function URL config for "e2e-furl-del-fn" was created
+    When I delete the function URL config for "e2e-furl-del-fn"
+    Then the command will succeed
+    And function "e2e-furl-del-fn" will have no URL config

--- a/lang/specification/core/features/lambda_function_url/list_function_url_configs.feature
+++ b/lang/specification/core/features/lambda_function_url/list_function_url_configs.feature
@@ -1,0 +1,8 @@
+@lambda @list_function_url_configs @controlplane
+Feature: Lambda ListFunctionUrlConfigs
+
+  @happy
+  Scenario: List function URL configs
+    When I list function URL configs
+    Then the command will succeed
+    And the output will contain "FunctionUrls"

--- a/lang/specification/core/features/memorydb/create_cluster.feature
+++ b/lang/specification/core/features/memorydb/create_cluster.feature
@@ -1,0 +1,22 @@
+@memorydb @create_cluster @controlplane
+Feature: MemoryDB CreateCluster
+
+  @happy
+  Scenario: Create a MemoryDB cluster
+    When I create a MemoryDB cluster "e2e-create-memorydb"
+    Then the command will succeed
+    And MemoryDB cluster "e2e-create-memorydb" will have status "available"
+
+  @happy
+  Scenario: Describe MemoryDB clusters lists a created cluster
+    Given a MemoryDB cluster "e2e-describe-memorydb" was created
+    When I describe MemoryDB clusters
+    Then the command will succeed
+    And MemoryDB cluster "e2e-describe-memorydb" will appear in the list
+
+  @happy
+  Scenario: Delete a MemoryDB cluster
+    Given a MemoryDB cluster "e2e-delete-memorydb" was created
+    When I delete MemoryDB cluster "e2e-delete-memorydb"
+    Then the command will succeed
+    And MemoryDB cluster "e2e-delete-memorydb" will not appear in the list

--- a/lang/specification/core/features/neptune/create_db_cluster.feature
+++ b/lang/specification/core/features/neptune/create_db_cluster.feature
@@ -1,0 +1,23 @@
+@neptune @create_db_cluster @controlplane
+Feature: Neptune CreateDBCluster
+
+  @happy
+  Scenario: Create a Neptune DB cluster
+    When I create a Neptune DB cluster "e2e-neptune-create"
+    Then the command will succeed
+    And cluster "e2e-neptune-create" will appear in describe-db-clusters
+
+  @happy
+  Scenario: Create and describe a Neptune DB cluster by identifier
+    Given a Neptune DB cluster "e2e-neptune-desc-id" was created
+    When I describe Neptune DB clusters with identifier "e2e-neptune-desc-id"
+    Then the command will succeed
+    And the output will contain exactly 1 DB cluster
+    And the output DB cluster identifier will be "e2e-neptune-desc-id"
+
+  @happy
+  Scenario: Create and delete a Neptune DB cluster
+    Given a Neptune DB cluster "e2e-neptune-delete" was created
+    When I delete Neptune DB cluster "e2e-neptune-delete"
+    Then the command will succeed
+    And cluster "e2e-neptune-delete" will not appear in describe-db-clusters

--- a/lang/specification/core/features/neptune/gremlin.feature
+++ b/lang/specification/core/features/neptune/gremlin.feature
@@ -1,0 +1,8 @@
+@neptune @gremlin @dataplane
+Feature: Neptune Gremlin endpoint
+
+  @happy
+  Scenario: Created Neptune cluster has an endpoint
+    When I create a Neptune DB cluster "e2e-neptune-gremlin"
+    Then the command will succeed
+    And the output will contain a non-empty Endpoint field

--- a/lang/specification/core/features/opensearch/create_domain.feature
+++ b/lang/specification/core/features/opensearch/create_domain.feature
@@ -1,0 +1,22 @@
+@opensearch @create_domain @controlplane
+Feature: OpenSearch CreateDomain
+
+  @happy
+  Scenario: Create a new OpenSearch domain
+    When I create opensearch domain "e2e-os-create-domain"
+    Then the command will succeed
+    And opensearch domain "e2e-os-create-domain" will exist
+
+  @happy
+  Scenario: List domains includes a created domain
+    Given an opensearch domain "e2e-os-create-list" was created
+    When I list opensearch domain names
+    Then the command will succeed
+    And the opensearch domain list will include "e2e-os-create-list"
+
+  @happy
+  Scenario: Delete an existing OpenSearch domain
+    Given an opensearch domain "e2e-os-create-del" was created
+    When I delete opensearch domain "e2e-os-create-del"
+    Then the command will succeed
+    And the opensearch domain list will not include "e2e-os-create-del"

--- a/lang/specification/core/features/rds/create_db_cluster.feature
+++ b/lang/specification/core/features/rds/create_db_cluster.feature
@@ -1,0 +1,15 @@
+@rds @create_db_cluster @controlplane
+Feature: RDS CreateDBCluster
+
+  @happy
+  Scenario: Create a new DB cluster
+    When I create a DB cluster "e2e-rds-create-cluster"
+    Then the command will succeed
+    And DB cluster "e2e-rds-create-cluster" will exist
+
+  @happy
+  Scenario: Describe DB clusters
+    Given a DB cluster "e2e-rds-describe-cluster" was created
+    When I describe DB clusters
+    Then the command will succeed
+    And DB cluster "e2e-rds-describe-cluster" will appear in the output

--- a/lang/specification/core/features/rds/create_db_instance.feature
+++ b/lang/specification/core/features/rds/create_db_instance.feature
@@ -1,0 +1,22 @@
+@rds @create_db_instance @controlplane
+Feature: RDS CreateDBInstance
+
+  @happy
+  Scenario: Create a new DB instance
+    When I create a DB instance "e2e-rds-create-instance"
+    Then the command will succeed
+    And DB instance "e2e-rds-create-instance" will exist
+
+  @happy
+  Scenario: Delete an existing DB instance
+    Given a DB instance "e2e-rds-create-del" was created
+    When I delete DB instance "e2e-rds-create-del"
+    Then the command will succeed
+    And DB instance "e2e-rds-create-del" will not exist
+
+  @happy
+  Scenario: Describe DB instances
+    Given a DB instance "e2e-rds-describe" was created
+    When I describe DB instances
+    Then the command will succeed
+    And DB instance "e2e-rds-describe" will appear in the output

--- a/lang/specification/core/features/s3api/abort_multipart_upload.feature
+++ b/lang/specification/core/features/s3api/abort_multipart_upload.feature
@@ -1,0 +1,9 @@
+@s3api @abort_multipart_upload @dataplane
+Feature: S3 AbortMultipartUpload
+
+  @happy
+  Scenario: Abort a multipart upload
+    Given a bucket "e2e-abort-mp" was created
+    And a multipart upload was created for key "e2e-abort.bin" in bucket "e2e-abort-mp"
+    When I abort the multipart upload
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/complete_multipart_upload.feature
+++ b/lang/specification/core/features/s3api/complete_multipart_upload.feature
@@ -1,0 +1,10 @@
+@s3api @complete_multipart_upload @dataplane
+Feature: S3 CompleteMultipartUpload
+
+  @happy
+  Scenario: Complete a multipart upload
+    Given a bucket "e2e-complete-mp" was created
+    And a multipart upload was created for key "e2e-complete.bin" in bucket "e2e-complete-mp"
+    And part 1 with content "complete-data" was uploaded
+    When I complete the multipart upload
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/copy_object.feature
+++ b/lang/specification/core/features/s3api/copy_object.feature
@@ -1,0 +1,10 @@
+@s3api @copy_object @dataplane
+Feature: S3 CopyObject
+
+  @happy
+  Scenario: Copy an object to a new key
+    Given a bucket "e2e-copy-obj" was created
+    And an object "source.txt" was put into bucket "e2e-copy-obj" with content "copy me"
+    When I copy object "dest.txt" in bucket "e2e-copy-obj" from source "e2e-copy-obj/source.txt"
+    Then the command will succeed
+    And object "dest.txt" in bucket "e2e-copy-obj" will have content "copy me"

--- a/lang/specification/core/features/s3api/create_bucket.feature
+++ b/lang/specification/core/features/s3api/create_bucket.feature
@@ -1,0 +1,8 @@
+@s3api @create_bucket @controlplane
+Feature: S3 CreateBucket
+
+  @happy
+  Scenario: Create a new bucket
+    When I create bucket "e2e-create-bkt"
+    Then the command will succeed
+    And bucket "e2e-create-bkt" will exist

--- a/lang/specification/core/features/s3api/create_multipart_upload.feature
+++ b/lang/specification/core/features/s3api/create_multipart_upload.feature
@@ -1,0 +1,19 @@
+@s3api @create_multipart_upload @dataplane
+Feature: S3 CreateMultipartUpload
+
+  @happy
+  Scenario: Full multipart upload workflow
+    Given a bucket "e2e-multipart" was created
+    When I create a multipart upload for key "e2e-multi.bin" in bucket "e2e-multipart"
+    Then the command will succeed
+    And the output will contain an upload ID
+
+  @happy
+  Scenario: Multipart upload produces correct object content
+    Given a bucket "e2e-multipart" was created
+    And a multipart upload was created for key "e2e-multi.bin" in bucket "e2e-multipart"
+    And part 1 with content "first-part-" was uploaded
+    And part 2 with content "second-part" was uploaded
+    When I complete the multipart upload
+    Then the command will succeed
+    And object "e2e-multi.bin" in bucket "e2e-multipart" will have binary content "first-part-second-part"

--- a/lang/specification/core/features/s3api/delete_bucket.feature
+++ b/lang/specification/core/features/s3api/delete_bucket.feature
@@ -1,0 +1,9 @@
+@s3api @delete_bucket @controlplane
+Feature: S3 DeleteBucket
+
+  @happy
+  Scenario: Delete an existing bucket
+    Given a bucket "e2e-del-bkt" was created
+    When I delete bucket "e2e-del-bkt"
+    Then the command will succeed
+    And bucket "e2e-del-bkt" will not appear in list-buckets

--- a/lang/specification/core/features/s3api/delete_bucket_tagging.feature
+++ b/lang/specification/core/features/s3api/delete_bucket_tagging.feature
@@ -1,0 +1,9 @@
+@s3api @delete_bucket_tagging @controlplane
+Feature: S3 DeleteBucketTagging
+
+  @happy
+  Scenario: Delete tags from a bucket
+    Given a bucket "e2e-del-tags" was created
+    And tags were set on bucket "e2e-del-tags" with key "env" and value "dev"
+    When I delete tags from bucket "e2e-del-tags"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/delete_bucket_website.feature
+++ b/lang/specification/core/features/s3api/delete_bucket_website.feature
@@ -1,0 +1,10 @@
+@s3api @delete_bucket_website @controlplane
+Feature: S3 DeleteBucketWebsite
+
+  @happy
+  Scenario: Delete website configuration from a bucket
+    Given a bucket "e2e-del-website-bkt" was created
+    And website configuration was set on bucket "e2e-del-website-bkt" with index "index.html"
+    When I delete website configuration from bucket "e2e-del-website-bkt"
+    Then the command will succeed
+    And bucket "e2e-del-website-bkt" will have no website configuration

--- a/lang/specification/core/features/s3api/delete_object.feature
+++ b/lang/specification/core/features/s3api/delete_object.feature
@@ -1,0 +1,10 @@
+@s3api @delete_object @dataplane
+Feature: S3 DeleteObject
+
+  @happy
+  Scenario: Delete an object from a bucket
+    Given a bucket "e2e-del-obj" was created
+    And an object "f.txt" was put into bucket "e2e-del-obj" with content "content"
+    When I delete object "f.txt" from bucket "e2e-del-obj"
+    Then the command will succeed
+    And bucket "e2e-del-obj" will have 0 objects

--- a/lang/specification/core/features/s3api/delete_objects.feature
+++ b/lang/specification/core/features/s3api/delete_objects.feature
@@ -1,0 +1,11 @@
+@s3api @delete_objects @dataplane
+Feature: S3 DeleteObjects
+
+  @happy
+  Scenario: Batch delete multiple objects
+    Given a bucket "e2e-del-objs" was created
+    And an object "a.txt" was put into bucket "e2e-del-objs" with content "aaa"
+    And an object "b.txt" was put into bucket "e2e-del-objs" with content "bbb"
+    When I delete objects "a.txt" and "b.txt" from bucket "e2e-del-objs"
+    Then the command will succeed
+    And bucket "e2e-del-objs" will have 0 objects

--- a/lang/specification/core/features/s3api/get_bucket_location.feature
+++ b/lang/specification/core/features/s3api/get_bucket_location.feature
@@ -1,0 +1,8 @@
+@s3api @get_bucket_location @controlplane
+Feature: S3 GetBucketLocation
+
+  @happy
+  Scenario: Get the location of a bucket
+    Given a bucket "e2e-get-loc" was created
+    When I get the location of bucket "e2e-get-loc"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/get_bucket_notification_configuration.feature
+++ b/lang/specification/core/features/s3api/get_bucket_notification_configuration.feature
@@ -1,0 +1,8 @@
+@s3api @get_bucket_notification_configuration @controlplane
+Feature: S3 GetBucketNotificationConfiguration
+
+  @happy
+  Scenario: Get notification configuration from a bucket
+    Given a bucket "e2e-get-notif" was created
+    When I get the notification configuration of bucket "e2e-get-notif"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/get_bucket_policy.feature
+++ b/lang/specification/core/features/s3api/get_bucket_policy.feature
@@ -1,0 +1,9 @@
+@s3api @get_bucket_policy @controlplane
+Feature: S3 GetBucketPolicy
+
+  @happy
+  Scenario: Get a policy from a bucket
+    Given a bucket "e2e-get-pol" was created
+    And a policy was set on bucket "e2e-get-pol"
+    When I get the policy of bucket "e2e-get-pol"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/get_bucket_tagging.feature
+++ b/lang/specification/core/features/s3api/get_bucket_tagging.feature
@@ -1,0 +1,9 @@
+@s3api @get_bucket_tagging @controlplane
+Feature: S3 GetBucketTagging
+
+  @happy
+  Scenario: Get tags from a bucket
+    Given a bucket "e2e-get-tags" was created
+    And tags were set on bucket "e2e-get-tags" with key "env" and value "staging"
+    When I get tags from bucket "e2e-get-tags"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/get_bucket_website.feature
+++ b/lang/specification/core/features/s3api/get_bucket_website.feature
@@ -1,0 +1,10 @@
+@s3api @get_bucket_website @controlplane
+Feature: S3 GetBucketWebsite
+
+  @happy
+  Scenario: Get website configuration from a bucket
+    Given a bucket "e2e-get-website-bkt" was created
+    And website configuration was set on bucket "e2e-get-website-bkt" with index "index.html"
+    When I get website configuration from bucket "e2e-get-website-bkt"
+    Then the command will succeed
+    And the output will contain website index document "index.html"

--- a/lang/specification/core/features/s3api/get_object.feature
+++ b/lang/specification/core/features/s3api/get_object.feature
@@ -1,0 +1,10 @@
+@s3api @get_object @dataplane
+Feature: S3 GetObject
+
+  @happy
+  Scenario: Get an object from a bucket
+    Given a bucket "e2e-get-obj" was created
+    And an object "doc.txt" was put into bucket "e2e-get-obj" with content "hello world"
+    When I get object "doc.txt" from bucket "e2e-get-obj"
+    Then the command will succeed
+    And the downloaded file will have content "hello world"

--- a/lang/specification/core/features/s3api/head_bucket.feature
+++ b/lang/specification/core/features/s3api/head_bucket.feature
@@ -1,0 +1,8 @@
+@s3api @head_bucket @controlplane
+Feature: S3 HeadBucket
+
+  @happy
+  Scenario: Head an existing bucket
+    Given a bucket "e2e-head-bkt" was created
+    When I head bucket "e2e-head-bkt"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/head_object.feature
+++ b/lang/specification/core/features/s3api/head_object.feature
@@ -1,0 +1,10 @@
+@s3api @head_object @dataplane
+Feature: S3 HeadObject
+
+  @happy
+  Scenario: Head an existing object
+    Given a bucket "e2e-head-obj" was created
+    And an object "h.txt" was put into bucket "e2e-head-obj" with content "data"
+    When I head object "h.txt" in bucket "e2e-head-obj"
+    Then the command will succeed
+    And the output will contain "ContentLength"

--- a/lang/specification/core/features/s3api/list_buckets.feature
+++ b/lang/specification/core/features/s3api/list_buckets.feature
@@ -1,0 +1,9 @@
+@s3api @list_buckets @controlplane
+Feature: S3 ListBuckets
+
+  @happy
+  Scenario: List buckets includes a created bucket
+    Given a bucket "e2e-list-bkts" was created
+    When I list buckets
+    Then the command will succeed
+    And the bucket list will include "e2e-list-bkts"

--- a/lang/specification/core/features/s3api/list_objects_v2.feature
+++ b/lang/specification/core/features/s3api/list_objects_v2.feature
@@ -1,0 +1,10 @@
+@s3api @list_objects_v2 @dataplane
+Feature: S3 ListObjectsV2
+
+  @happy
+  Scenario: List objects includes a created object
+    Given a bucket "e2e-listobj" was created
+    And an object "l.txt" was put into bucket "e2e-listobj" with content "x"
+    When I list objects in bucket "e2e-listobj"
+    Then the command will succeed
+    And the object list will include "l.txt"

--- a/lang/specification/core/features/s3api/list_parts.feature
+++ b/lang/specification/core/features/s3api/list_parts.feature
@@ -1,0 +1,10 @@
+@s3api @list_parts @dataplane
+Feature: S3 ListParts
+
+  @happy
+  Scenario: List parts of a multipart upload
+    Given a bucket "e2e-list-parts" was created
+    And a multipart upload was created for key "bigfile.bin" in bucket "e2e-list-parts"
+    And part 1 with content "part1data" was uploaded
+    When I list parts of the multipart upload
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/put_bucket_notification_configuration.feature
+++ b/lang/specification/core/features/s3api/put_bucket_notification_configuration.feature
@@ -1,0 +1,8 @@
+@s3api @put_bucket_notification_configuration @controlplane
+Feature: S3 PutBucketNotificationConfiguration
+
+  @happy
+  Scenario: Set notification configuration on a bucket
+    Given a bucket "e2e-put-notif" was created
+    When I put a notification configuration on bucket "e2e-put-notif"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/put_bucket_policy.feature
+++ b/lang/specification/core/features/s3api/put_bucket_policy.feature
@@ -1,0 +1,8 @@
+@s3api @put_bucket_policy @controlplane
+Feature: S3 PutBucketPolicy
+
+  @happy
+  Scenario: Set a policy on a bucket
+    Given a bucket "e2e-put-pol" was created
+    When I put a policy on bucket "e2e-put-pol"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/put_bucket_tagging.feature
+++ b/lang/specification/core/features/s3api/put_bucket_tagging.feature
@@ -1,0 +1,8 @@
+@s3api @put_bucket_tagging @controlplane
+Feature: S3 PutBucketTagging
+
+  @happy
+  Scenario: Set tags on a bucket
+    Given a bucket "e2e-put-tags" was created
+    When I put tags on bucket "e2e-put-tags" with key "env" and value "test"
+    Then the command will succeed

--- a/lang/specification/core/features/s3api/put_bucket_website.feature
+++ b/lang/specification/core/features/s3api/put_bucket_website.feature
@@ -1,0 +1,9 @@
+@s3api @put_bucket_website @controlplane
+Feature: S3 PutBucketWebsite
+
+  @happy
+  Scenario: Set website configuration on a bucket
+    Given a bucket "e2e-put-website-bkt" was created
+    When I put website configuration on bucket "e2e-put-website-bkt" with index "index.html"
+    Then the command will succeed
+    And bucket "e2e-put-website-bkt" will have website index document "index.html"

--- a/lang/specification/core/features/s3api/put_object.feature
+++ b/lang/specification/core/features/s3api/put_object.feature
@@ -1,0 +1,10 @@
+@s3api @put_object @dataplane
+Feature: S3 PutObject
+
+  @happy
+  Scenario: Put an object into a bucket
+    Given a bucket "e2e-put-obj" was created
+    And a file was created with content "upload content"
+    When I put object "file.txt" into bucket "e2e-put-obj" from the file
+    Then the command will succeed
+    And object "file.txt" in bucket "e2e-put-obj" will have content "upload content"

--- a/lang/specification/core/features/s3api/upload_part.feature
+++ b/lang/specification/core/features/s3api/upload_part.feature
@@ -1,0 +1,10 @@
+@s3api @upload_part @dataplane
+Feature: S3 UploadPart
+
+  @happy
+  Scenario: Upload a part to a multipart upload
+    Given a bucket "e2e-upload-part" was created
+    And a multipart upload was created for key "e2e-part.bin" in bucket "e2e-upload-part"
+    When I upload part 1 with content "part-data"
+    Then the command will succeed
+    And the output will contain an ETag

--- a/lang/specification/core/features/s3tables/create_table.feature
+++ b/lang/specification/core/features/s3tables/create_table.feature
@@ -1,0 +1,10 @@
+@s3tables @create_table @controlplane
+Feature: S3Tables CreateTable
+
+  @happy
+  Scenario: Create a table in a namespace
+    Given a table bucket "e2e-tbl-lifecycle-tb" was created
+    And a namespace "e2e-tbl-ns" was created in table bucket "e2e-tbl-lifecycle-tb"
+    When I create table "e2e-events" in namespace "e2e-tbl-ns" of table bucket "e2e-tbl-lifecycle-tb"
+    Then the command will succeed
+    And the table list in namespace "e2e-tbl-ns" of table bucket "e2e-tbl-lifecycle-tb" will include "e2e-events"

--- a/lang/specification/core/features/s3tables/create_table_bucket.feature
+++ b/lang/specification/core/features/s3tables/create_table_bucket.feature
@@ -1,0 +1,8 @@
+@s3tables @create_table_bucket @controlplane
+Feature: S3Tables CreateTableBucket
+
+  @happy
+  Scenario: Create a new table bucket
+    When I create table bucket "e2e-create-tb"
+    Then the command will succeed
+    And the table bucket list will include "e2e-create-tb"

--- a/lang/specification/core/features/secretsmanager/create_secret.feature
+++ b/lang/specification/core/features/secretsmanager/create_secret.feature
@@ -1,0 +1,15 @@
+@secretsmanager @create_secret @controlplane
+Feature: SecretsManager CreateSecret
+
+  @happy
+  Scenario: Create a new secret with a string value
+    When I create secret "e2e-create-secret" with value "s3cret"
+    Then the command will succeed
+    And the output will contain secret name "e2e-create-secret"
+    And secret "e2e-create-secret" will have value "s3cret"
+
+  @happy
+  Scenario: Create a secret with a description
+    When I create secret "e2e-create-secret-desc" with value "val" and description "A test secret"
+    Then the command will succeed
+    And secret "e2e-create-secret-desc" will appear in describe-secret

--- a/lang/specification/core/features/secretsmanager/delete_secret.feature
+++ b/lang/specification/core/features/secretsmanager/delete_secret.feature
@@ -1,0 +1,9 @@
+@secretsmanager @delete_secret @controlplane
+Feature: SecretsManager DeleteSecret
+
+  @happy
+  Scenario: Delete an existing secret with force flag
+    Given a secret "e2e-del-secret" was created with value "gone"
+    When I delete secret "e2e-del-secret" with force delete without recovery
+    Then the command will succeed
+    And secret "e2e-del-secret" will not appear in list-secrets

--- a/lang/specification/core/features/secretsmanager/describe_secret.feature
+++ b/lang/specification/core/features/secretsmanager/describe_secret.feature
@@ -1,0 +1,9 @@
+@secretsmanager @describe_secret @controlplane
+Feature: SecretsManager DescribeSecret
+
+  @happy
+  Scenario: Describe an existing secret
+    Given a secret "e2e-desc-secret" was created with value "val"
+    When I describe secret "e2e-desc-secret"
+    Then the command will succeed
+    And the output will contain secret name "e2e-desc-secret"

--- a/lang/specification/core/features/secretsmanager/get_resource_policy.feature
+++ b/lang/specification/core/features/secretsmanager/get_resource_policy.feature
@@ -1,0 +1,8 @@
+@secretsmanager @get_resource_policy @controlplane
+Feature: SecretsManager GetResourcePolicy
+
+  @happy
+  Scenario: Get resource policy for an existing secret
+    Given a secret "e2e-get-resource-policy" was created with value "val"
+    When I get resource policy for "e2e-get-resource-policy"
+    Then the command will succeed

--- a/lang/specification/core/features/secretsmanager/get_secret_value.feature
+++ b/lang/specification/core/features/secretsmanager/get_secret_value.feature
@@ -1,0 +1,9 @@
+@secretsmanager @get_secret_value @dataplane
+Feature: SecretsManager GetSecretValue
+
+  @happy
+  Scenario: Get the value of an existing secret
+    Given a secret "e2e-get-sv" was created with value "my-secret"
+    When I get secret value for "e2e-get-sv"
+    Then the command will succeed
+    And the output will contain secret value "my-secret"

--- a/lang/specification/core/features/secretsmanager/list_secret_version_ids.feature
+++ b/lang/specification/core/features/secretsmanager/list_secret_version_ids.feature
@@ -1,0 +1,8 @@
+@secretsmanager @list_secret_version_ids @controlplane
+Feature: SecretsManager ListSecretVersionIds
+
+  @happy
+  Scenario: List version IDs for an existing secret
+    Given a secret "e2e-list-version-ids" was created with value "val"
+    When I list secret version IDs for "e2e-list-version-ids"
+    Then the command will succeed

--- a/lang/specification/core/features/secretsmanager/list_secrets.feature
+++ b/lang/specification/core/features/secretsmanager/list_secrets.feature
@@ -1,0 +1,9 @@
+@secretsmanager @list_secrets @controlplane
+Feature: SecretsManager ListSecrets
+
+  @happy
+  Scenario: List secrets includes a created secret
+    Given a secret "e2e-list-secrets" was created with value "x"
+    When I list secrets
+    Then the command will succeed
+    And the secret list will include "e2e-list-secrets"

--- a/lang/specification/core/features/secretsmanager/put_secret_value.feature
+++ b/lang/specification/core/features/secretsmanager/put_secret_value.feature
@@ -1,0 +1,9 @@
+@secretsmanager @put_secret_value @dataplane
+Feature: SecretsManager PutSecretValue
+
+  @happy
+  Scenario: Put a new value for an existing secret
+    Given a secret "e2e-put-sv" was created with value "old"
+    When I put secret value "new-value" for "e2e-put-sv"
+    Then the command will succeed
+    And secret "e2e-put-sv" will have value "new-value"

--- a/lang/specification/core/features/secretsmanager/restore_secret.feature
+++ b/lang/specification/core/features/secretsmanager/restore_secret.feature
@@ -1,0 +1,10 @@
+@secretsmanager @restore_secret @controlplane
+Feature: SecretsManager RestoreSecret
+
+  @happy
+  Scenario: Restore a previously deleted secret
+    Given a secret "e2e-restore-secret" was created with value "val"
+    And the secret "e2e-restore-secret" was deleted
+    When I restore secret "e2e-restore-secret"
+    Then the command will succeed
+    And secret "e2e-restore-secret" will appear in describe-secret

--- a/lang/specification/core/features/secretsmanager/tag_resource.feature
+++ b/lang/specification/core/features/secretsmanager/tag_resource.feature
@@ -1,0 +1,9 @@
+@secretsmanager @tag_resource @controlplane
+Feature: SecretsManager TagResource
+
+  @happy
+  Scenario: Tag an existing secret
+    Given a secret "e2e-tag-resource" was created with value "val"
+    When I tag secret "e2e-tag-resource" with tags [{"Key": "env", "Value": "test"}]
+    Then the command will succeed
+    And secret "e2e-tag-resource" will have tag "env" with value "test"

--- a/lang/specification/core/features/secretsmanager/untag_resource.feature
+++ b/lang/specification/core/features/secretsmanager/untag_resource.feature
@@ -1,0 +1,10 @@
+@secretsmanager @untag_resource @controlplane
+Feature: SecretsManager UntagResource
+
+  @happy
+  Scenario: Untag an existing secret
+    Given a secret "e2e-untag-resource" was created with value "val"
+    And tags [{"Key": "env", "Value": "test"}] were added to secret "e2e-untag-resource"
+    When I untag secret "e2e-untag-resource" with tag keys ["env"]
+    Then the command will succeed
+    And secret "e2e-untag-resource" will not have tag "env"

--- a/lang/specification/core/features/secretsmanager/update_secret.feature
+++ b/lang/specification/core/features/secretsmanager/update_secret.feature
@@ -1,0 +1,9 @@
+@secretsmanager @update_secret @controlplane
+Feature: SecretsManager UpdateSecret
+
+  @happy
+  Scenario: Update an existing secret with a new value
+    Given a secret "e2e-update-secret" was created with value "old-val"
+    When I update secret "e2e-update-secret" with value "new-val"
+    Then the command will succeed
+    And secret "e2e-update-secret" will have value "new-val"

--- a/lang/specification/core/features/sns/confirm_subscription.feature
+++ b/lang/specification/core/features/sns/confirm_subscription.feature
@@ -1,0 +1,8 @@
+@sns @confirm_subscription @controlplane
+Feature: SNS ConfirmSubscription
+
+  @happy
+  Scenario: Confirm a subscription with a token
+    Given a topic "e2e-confirm-sub" was created
+    When I confirm subscription for topic "e2e-confirm-sub" with token "dummy-token"
+    Then the command will succeed

--- a/lang/specification/core/features/sns/create_topic.feature
+++ b/lang/specification/core/features/sns/create_topic.feature
@@ -1,0 +1,8 @@
+@sns @create_topic @controlplane
+Feature: SNS CreateTopic
+
+  @happy
+  Scenario: Create a new topic
+    When I create topic "e2e-create-topic"
+    Then the command will succeed
+    And the topic "e2e-create-topic" will appear in the topic list

--- a/lang/specification/core/features/sns/delete_topic.feature
+++ b/lang/specification/core/features/sns/delete_topic.feature
@@ -1,0 +1,9 @@
+@sns @delete_topic @controlplane
+Feature: SNS DeleteTopic
+
+  @happy
+  Scenario: Delete an existing topic
+    Given a topic "e2e-del-topic" was created
+    When I delete the topic "e2e-del-topic"
+    Then the command will succeed
+    And the topic "e2e-del-topic" will not appear in the topic list

--- a/lang/specification/core/features/sns/get_subscription_attributes.feature
+++ b/lang/specification/core/features/sns/get_subscription_attributes.feature
@@ -1,0 +1,9 @@
+@sns @get_subscription_attributes @controlplane
+Feature: SNS GetSubscriptionAttributes
+
+  @happy
+  Scenario: Get attributes of a subscription
+    Given a topic "e2e-get-sub-attrs" was created
+    And an SQS subscription to "arn:aws:sqs:us-east-1:000000000000:e2e-get-sub-attrs-q" was added to topic "e2e-get-sub-attrs"
+    When I get subscription attributes for the subscription on topic "e2e-get-sub-attrs"
+    Then the command will succeed

--- a/lang/specification/core/features/sns/get_topic_attributes.feature
+++ b/lang/specification/core/features/sns/get_topic_attributes.feature
@@ -1,0 +1,8 @@
+@sns @get_topic_attributes @controlplane
+Feature: SNS GetTopicAttributes
+
+  @happy
+  Scenario: Get attributes of a topic
+    Given a topic "e2e-get-topic-attrs" was created
+    When I get topic attributes for topic "e2e-get-topic-attrs"
+    Then the command will succeed

--- a/lang/specification/core/features/sns/list_subscriptions.feature
+++ b/lang/specification/core/features/sns/list_subscriptions.feature
@@ -1,0 +1,8 @@
+@sns @list_subscriptions @controlplane
+Feature: SNS ListSubscriptions
+
+  @happy
+  Scenario: List all subscriptions
+    When I list subscriptions
+    Then the command will succeed
+    And the output will contain a ListSubscriptionsResponse

--- a/lang/specification/core/features/sns/list_subscriptions_by_topic.feature
+++ b/lang/specification/core/features/sns/list_subscriptions_by_topic.feature
@@ -1,0 +1,8 @@
+@sns @list_subscriptions_by_topic @controlplane
+Feature: SNS ListSubscriptionsByTopic
+
+  @happy
+  Scenario: List subscriptions for a specific topic
+    Given a topic "e2e-list-subs-topic" was created
+    When I list subscriptions by topic "e2e-list-subs-topic"
+    Then the command will succeed

--- a/lang/specification/core/features/sns/list_tags_for_resource.feature
+++ b/lang/specification/core/features/sns/list_tags_for_resource.feature
@@ -1,0 +1,8 @@
+@sns @list_tags_for_resource @controlplane
+Feature: SNS ListTagsForResource
+
+  @happy
+  Scenario: List tags for a topic
+    Given a topic "e2e-list-tags-res" was created
+    When I list tags for resource "e2e-list-tags-res"
+    Then the command will succeed

--- a/lang/specification/core/features/sns/list_topics.feature
+++ b/lang/specification/core/features/sns/list_topics.feature
@@ -1,0 +1,9 @@
+@sns @list_topics @controlplane
+Feature: SNS ListTopics
+
+  @happy
+  Scenario: List topics includes a previously created topic
+    Given a topic "e2e-list-topics" was created
+    When I list topics
+    Then the command will succeed
+    And the topic "e2e-list-topics" will appear in the topic list

--- a/lang/specification/core/features/sns/publish.feature
+++ b/lang/specification/core/features/sns/publish.feature
@@ -1,0 +1,9 @@
+@sns @publish @dataplane
+Feature: SNS Publish
+
+  @happy
+  Scenario: Publish a message to a topic
+    Given a topic "e2e-publish-topic" was created
+    When I publish message "hello from e2e" to topic "e2e-publish-topic"
+    Then the command will succeed
+    And the output will contain a PublishResponse

--- a/lang/specification/core/features/sns/set_subscription_attributes.feature
+++ b/lang/specification/core/features/sns/set_subscription_attributes.feature
@@ -1,0 +1,10 @@
+@sns @set_subscription_attributes @controlplane
+Feature: SNS SetSubscriptionAttributes
+
+  @happy
+  Scenario: Set attributes on a subscription
+    Given a topic "e2e-set-sub-attrs" was created
+    And an SQS subscription to "arn:aws:sqs:us-east-1:000000000000:e2e-set-sub-attrs-q" was added to topic "e2e-set-sub-attrs"
+    When I set subscription attribute "RawMessageDelivery" to "true" for the subscription on topic "e2e-set-sub-attrs"
+    Then the command will succeed
+    And the subscription on topic "e2e-set-sub-attrs" will have attribute "RawMessageDelivery" equal to "true"

--- a/lang/specification/core/features/sns/set_topic_attributes.feature
+++ b/lang/specification/core/features/sns/set_topic_attributes.feature
@@ -1,0 +1,9 @@
+@sns @set_topic_attributes @controlplane
+Feature: SNS SetTopicAttributes
+
+  @happy
+  Scenario: Set attributes on a topic
+    Given a topic "e2e-set-topic-attrs" was created
+    When I set topic attribute "DisplayName" to "E2E Test Topic" for topic "e2e-set-topic-attrs"
+    Then the command will succeed
+    And the topic "e2e-set-topic-attrs" will have display name "E2E Test Topic"

--- a/lang/specification/core/features/sns/subscribe.feature
+++ b/lang/specification/core/features/sns/subscribe.feature
@@ -1,0 +1,9 @@
+@sns @subscribe @controlplane
+Feature: SNS Subscribe
+
+  @happy
+  Scenario: Subscribe an SQS queue to a topic
+    Given a topic "e2e-sub-topic" was created
+    When I subscribe "arn:aws:sqs:us-east-1:000000000000:e2e-sub-queue" with protocol "sqs" to the topic "e2e-sub-topic"
+    Then the command will succeed
+    And the topic "e2e-sub-topic" will have a subscription in the subscription list

--- a/lang/specification/core/features/sns/tag_resource.feature
+++ b/lang/specification/core/features/sns/tag_resource.feature
@@ -1,0 +1,9 @@
+@sns @tag_resource @controlplane
+Feature: SNS TagResource
+
+  @happy
+  Scenario: Tag a topic
+    Given a topic "e2e-tag-res" was created
+    When I tag resource "e2e-tag-res" with tags '[{"Key":"env","Value":"test"}]'
+    Then the command will succeed
+    And topic "e2e-tag-res" will have tag "env" with value "test"

--- a/lang/specification/core/features/sns/unsubscribe.feature
+++ b/lang/specification/core/features/sns/unsubscribe.feature
@@ -1,0 +1,10 @@
+@sns @unsubscribe @controlplane
+Feature: SNS Unsubscribe
+
+  @happy
+  Scenario: Unsubscribe from a topic
+    Given a topic "e2e-unsub-topic" was created
+    And an SQS subscription to "arn:aws:sqs:us-east-1:000000000000:e2e-unsub-queue" was added to topic "e2e-unsub-topic"
+    When I unsubscribe the subscription on topic "e2e-unsub-topic"
+    Then the command will succeed
+    And the topic "e2e-unsub-topic" will not have a subscription in the subscription list

--- a/lang/specification/core/features/sns/untag_resource.feature
+++ b/lang/specification/core/features/sns/untag_resource.feature
@@ -1,0 +1,10 @@
+@sns @untag_resource @controlplane
+Feature: SNS UntagResource
+
+  @happy
+  Scenario: Untag a topic
+    Given a topic "e2e-untag-res" was created
+    And tags '[{"Key":"env","Value":"test"}]' were added to topic "e2e-untag-res"
+    When I untag resource "e2e-untag-res" with tag keys '["env"]'
+    Then the command will succeed
+    And topic "e2e-untag-res" will not have tag "env"

--- a/lang/specification/core/features/sqs/change_message_visibility.feature
+++ b/lang/specification/core/features/sqs/change_message_visibility.feature
@@ -1,0 +1,10 @@
+@sqs @change_message_visibility @dataplane
+Feature: SQS ChangeMessageVisibility
+
+  @happy
+  Scenario: Change visibility timeout of a message
+    Given a queue "e2e-chg-vis" was created
+    And a message "vis-test" was sent to queue "e2e-chg-vis"
+    And a message was received from queue "e2e-chg-vis"
+    When I change the visibility timeout to "60" for the received message in queue "e2e-chg-vis"
+    Then the command will succeed

--- a/lang/specification/core/features/sqs/change_message_visibility_batch.feature
+++ b/lang/specification/core/features/sqs/change_message_visibility_batch.feature
@@ -1,0 +1,10 @@
+@sqs @change_message_visibility_batch @dataplane
+Feature: SQS ChangeMessageVisibilityBatch
+
+  @happy
+  Scenario: Change visibility timeout of messages in batch
+    Given a queue "e2e-chg-vis-batch" was created
+    And a message "vis-batch-test" was sent to queue "e2e-chg-vis-batch"
+    And a message was received from queue "e2e-chg-vis-batch"
+    When I change message visibility in batch with timeout "60" for the received message in queue "e2e-chg-vis-batch"
+    Then the command will succeed

--- a/lang/specification/core/features/sqs/create_queue.feature
+++ b/lang/specification/core/features/sqs/create_queue.feature
@@ -1,0 +1,8 @@
+@sqs @create_queue @controlplane
+Feature: SQS CreateQueue
+
+  @happy
+  Scenario: Create a new queue
+    When I create a queue named "e2e-create-q"
+    Then the command will succeed
+    And the queue "e2e-create-q" will appear in the queue list

--- a/lang/specification/core/features/sqs/delete_message.feature
+++ b/lang/specification/core/features/sqs/delete_message.feature
@@ -1,0 +1,11 @@
+@sqs @delete_message @dataplane
+Feature: SQS DeleteMessage
+
+  @happy
+  Scenario: Delete a message from a queue
+    Given a queue "e2e-delmsg" was created
+    And a message "to-delete" was sent to queue "e2e-delmsg"
+    And a message was received from queue "e2e-delmsg"
+    When I delete the received message from queue "e2e-delmsg"
+    Then the command will succeed
+    And queue "e2e-delmsg" will have approximate message count "0"

--- a/lang/specification/core/features/sqs/delete_message_batch.feature
+++ b/lang/specification/core/features/sqs/delete_message_batch.feature
@@ -1,0 +1,11 @@
+@sqs @delete_message_batch @dataplane
+Feature: SQS DeleteMessageBatch
+
+  @happy
+  Scenario: Delete messages in batch
+    Given a queue "e2e-delmsg-batch" was created
+    And a message "batch-delete-me" was sent to queue "e2e-delmsg-batch"
+    And a message was received from queue "e2e-delmsg-batch"
+    When I delete messages in batch for the received message in queue "e2e-delmsg-batch"
+    Then the command will succeed
+    And queue "e2e-delmsg-batch" will have approximate message count "0"

--- a/lang/specification/core/features/sqs/delete_queue.feature
+++ b/lang/specification/core/features/sqs/delete_queue.feature
@@ -1,0 +1,9 @@
+@sqs @delete_queue @controlplane
+Feature: SQS DeleteQueue
+
+  @happy
+  Scenario: Delete an existing queue
+    Given a queue "e2e-del-q" was created
+    When I delete the queue "e2e-del-q"
+    Then the command will succeed
+    And the queue "e2e-del-q" will not appear in the queue list

--- a/lang/specification/core/features/sqs/get_queue_attributes.feature
+++ b/lang/specification/core/features/sqs/get_queue_attributes.feature
@@ -1,0 +1,9 @@
+@sqs @get_queue_attributes @controlplane
+Feature: SQS GetQueueAttributes
+
+  @happy
+  Scenario: Get attributes of a queue
+    Given a queue "e2e-getattr-q" was created
+    When I get queue attributes for "e2e-getattr-q"
+    Then the command will succeed
+    And the output will contain "GetQueueAttributesResponse"

--- a/lang/specification/core/features/sqs/get_queue_url.feature
+++ b/lang/specification/core/features/sqs/get_queue_url.feature
@@ -1,0 +1,8 @@
+@sqs @get_queue_url @controlplane
+Feature: SQS GetQueueUrl
+
+  @happy
+  Scenario: Get the URL of a queue
+    Given a queue "e2e-get-queue-url" was created
+    When I get the queue URL for "e2e-get-queue-url"
+    Then the command will succeed

--- a/lang/specification/core/features/sqs/list_dead_letter_source_queues.feature
+++ b/lang/specification/core/features/sqs/list_dead_letter_source_queues.feature
@@ -1,0 +1,8 @@
+@sqs @list_dead_letter_source_queues @controlplane
+Feature: SQS ListDeadLetterSourceQueues
+
+  @happy
+  Scenario: List dead letter source queues
+    Given a queue "e2e-list-dlq-src" was created
+    When I list dead letter source queues for "e2e-list-dlq-src"
+    Then the command will succeed

--- a/lang/specification/core/features/sqs/list_queue_tags.feature
+++ b/lang/specification/core/features/sqs/list_queue_tags.feature
@@ -1,0 +1,8 @@
+@sqs @list_queue_tags @controlplane
+Feature: SQS ListQueueTags
+
+  @happy
+  Scenario: List tags of a queue
+    Given a queue "e2e-list-q-tags" was created
+    When I list queue tags for "e2e-list-q-tags"
+    Then the command will succeed

--- a/lang/specification/core/features/sqs/list_queues.feature
+++ b/lang/specification/core/features/sqs/list_queues.feature
@@ -1,0 +1,9 @@
+@sqs @list_queues @controlplane
+Feature: SQS ListQueues
+
+  @happy
+  Scenario: List queues includes a created queue
+    Given a queue "e2e-list-q" was created
+    When I list queues
+    Then the command will succeed
+    And the output will contain queue "e2e-list-q"

--- a/lang/specification/core/features/sqs/purge_queue.feature
+++ b/lang/specification/core/features/sqs/purge_queue.feature
@@ -1,0 +1,10 @@
+@sqs @purge_queue @controlplane
+Feature: SQS PurgeQueue
+
+  @happy
+  Scenario: Purge all messages from a queue
+    Given a queue "e2e-purge-q" was created
+    And a message "msg1" was sent to queue "e2e-purge-q"
+    When I purge queue "e2e-purge-q"
+    Then the command will succeed
+    And queue "e2e-purge-q" will have approximate message count "0"

--- a/lang/specification/core/features/sqs/receive_message.feature
+++ b/lang/specification/core/features/sqs/receive_message.feature
@@ -1,0 +1,10 @@
+@sqs @receive_message @dataplane
+Feature: SQS ReceiveMessage
+
+  @happy
+  Scenario: Receive a message from a queue
+    Given a queue "e2e-recv-msg" was created
+    And a message "test-body" was sent to queue "e2e-recv-msg"
+    When I receive a message from queue "e2e-recv-msg"
+    Then the command will succeed
+    And the output will contain a message with body "test-body"

--- a/lang/specification/core/features/sqs/send_message.feature
+++ b/lang/specification/core/features/sqs/send_message.feature
@@ -1,0 +1,9 @@
+@sqs @send_message @dataplane
+Feature: SQS SendMessage
+
+  @happy
+  Scenario: Send a message to a queue
+    Given a queue "e2e-send-msg" was created
+    When I send a message "hello from e2e" to queue "e2e-send-msg"
+    Then the command will succeed
+    And queue "e2e-send-msg" will contain a message with body "hello from e2e"

--- a/lang/specification/core/features/sqs/send_message_batch.feature
+++ b/lang/specification/core/features/sqs/send_message_batch.feature
@@ -1,0 +1,9 @@
+@sqs @send_message_batch @dataplane
+Feature: SQS SendMessageBatch
+
+  @happy
+  Scenario: Send messages in batch
+    Given a queue "e2e-send-msg-batch" was created
+    When I send a message batch with entries '[{"Id":"1","MessageBody":"msg1"}]' to queue "e2e-send-msg-batch"
+    Then the command will succeed
+    And queue "e2e-send-msg-batch" will contain a message with body "msg1"

--- a/lang/specification/core/features/sqs/set_queue_attributes.feature
+++ b/lang/specification/core/features/sqs/set_queue_attributes.feature
@@ -1,0 +1,9 @@
+@sqs @set_queue_attributes @controlplane
+Feature: SQS SetQueueAttributes
+
+  @happy
+  Scenario: Set attributes on a queue
+    Given a queue "e2e-set-queue-attrs" was created
+    When I set queue attributes '{"VisibilityTimeout":"30"}' on queue "e2e-set-queue-attrs"
+    Then the command will succeed
+    And queue "e2e-set-queue-attrs" will have attribute "VisibilityTimeout" equal to "30"

--- a/lang/specification/core/features/sqs/tag_queue.feature
+++ b/lang/specification/core/features/sqs/tag_queue.feature
@@ -1,0 +1,9 @@
+@sqs @tag_queue @controlplane
+Feature: SQS TagQueue
+
+  @happy
+  Scenario: Tag a queue
+    Given a queue "e2e-tag-q" was created
+    When I tag queue "e2e-tag-q" with tags '{"env":"test"}'
+    Then the command will succeed
+    And queue "e2e-tag-q" will have tag "env" with value "test"

--- a/lang/specification/core/features/sqs/untag_queue.feature
+++ b/lang/specification/core/features/sqs/untag_queue.feature
@@ -1,0 +1,10 @@
+@sqs @untag_queue @controlplane
+Feature: SQS UntagQueue
+
+  @happy
+  Scenario: Untag a queue
+    Given a queue "e2e-untag-q" was created
+    And queue "e2e-untag-q" was tagged with '{"env":"test"}'
+    When I untag queue "e2e-untag-q" with tag keys '["env"]'
+    Then the command will succeed
+    And queue "e2e-untag-q" will not have tag "env"

--- a/lang/specification/core/features/ssm/add_tags_to_resource.feature
+++ b/lang/specification/core/features/ssm/add_tags_to_resource.feature
@@ -1,0 +1,8 @@
+@ssm @add_tags_to_resource @controlplane
+Feature: SSM AddTagsToResource
+
+  @happy
+  Scenario: Add tags to a parameter
+    Given a parameter "/e2e/add-tags-test" was created with value "val1" and type "String"
+    When I add tags [{"Key": "env", "Value": "test"}] to parameter "/e2e/add-tags-test"
+    Then the command will succeed

--- a/lang/specification/core/features/ssm/delete_parameter.feature
+++ b/lang/specification/core/features/ssm/delete_parameter.feature
@@ -1,0 +1,9 @@
+@ssm @delete_parameter @controlplane
+Feature: SSM DeleteParameter
+
+  @happy
+  Scenario: Delete an existing parameter
+    Given a parameter "/e2e/del-param-test" was created with value "gone" and type "String"
+    When I delete parameter "/e2e/del-param-test"
+    Then the command will succeed
+    And parameter "/e2e/del-param-test" will not appear in describe-parameters

--- a/lang/specification/core/features/ssm/delete_parameters.feature
+++ b/lang/specification/core/features/ssm/delete_parameters.feature
@@ -1,0 +1,8 @@
+@ssm @delete_parameters @controlplane
+Feature: SSM DeleteParameters
+
+  @happy
+  Scenario: Delete multiple parameters
+    Given a parameter "/e2e/del-params-test" was created with value "val1" and type "String"
+    When I delete parameters ["/e2e/del-params-test"]
+    Then the command will succeed

--- a/lang/specification/core/features/ssm/describe_parameters.feature
+++ b/lang/specification/core/features/ssm/describe_parameters.feature
@@ -1,0 +1,9 @@
+@ssm @describe_parameters @controlplane
+Feature: SSM DescribeParameters
+
+  @happy
+  Scenario: List parameters includes a known parameter
+    Given a parameter "/e2e/desc-params-test" was created with value "x" and type "String"
+    When I describe parameters
+    Then the command will succeed
+    And the parameter list will include "/e2e/desc-params-test"

--- a/lang/specification/core/features/ssm/get_parameter.feature
+++ b/lang/specification/core/features/ssm/get_parameter.feature
@@ -1,0 +1,9 @@
+@ssm @get_parameter @dataplane
+Feature: SSM GetParameter
+
+  @happy
+  Scenario: Get an existing parameter
+    Given a parameter "/e2e/get-param-test" was created with value "hello" and type "String"
+    When I get parameter "/e2e/get-param-test"
+    Then the command will succeed
+    And the output will contain parameter value "hello"

--- a/lang/specification/core/features/ssm/get_parameters.feature
+++ b/lang/specification/core/features/ssm/get_parameters.feature
@@ -1,0 +1,9 @@
+@ssm @get_parameters @dataplane
+Feature: SSM GetParameters
+
+  @happy
+  Scenario: Get multiple parameters by name
+    Given a parameter "/e2e/get-params-test-1" was created with value "val1" and type "String"
+    And a parameter "/e2e/get-params-test-2" was created with value "val2" and type "String"
+    When I get parameters ["/e2e/get-params-test-1", "/e2e/get-params-test-2"]
+    Then the command will succeed

--- a/lang/specification/core/features/ssm/get_parameters_by_path.feature
+++ b/lang/specification/core/features/ssm/get_parameters_by_path.feature
@@ -1,0 +1,11 @@
+@ssm @get_parameters_by_path @dataplane
+Feature: SSM GetParametersByPath
+
+  @happy
+  Scenario: Get parameters under a path
+    Given a parameter "/e2e/path-test/p1" was created with value "a" and type "String"
+    And a parameter "/e2e/path-test/p2" was created with value "b" and type "String"
+    When I get parameters by path "/e2e/path-test"
+    Then the command will succeed
+    And the parameter list will include "/e2e/path-test/p1"
+    And the parameter list will include "/e2e/path-test/p2"

--- a/lang/specification/core/features/ssm/list_tags_for_resource.feature
+++ b/lang/specification/core/features/ssm/list_tags_for_resource.feature
@@ -1,0 +1,8 @@
+@ssm @list_tags_for_resource @controlplane
+Feature: SSM ListTagsForResource
+
+  @happy
+  Scenario: List tags for a parameter
+    Given a parameter "/e2e/list-tags-test" was created with value "val1" and type "String"
+    When I list tags for parameter "/e2e/list-tags-test"
+    Then the command will succeed

--- a/lang/specification/core/features/ssm/put_parameter.feature
+++ b/lang/specification/core/features/ssm/put_parameter.feature
@@ -1,0 +1,21 @@
+@ssm @put_parameter @dataplane
+Feature: SSM PutParameter
+
+  @happy
+  Scenario: Put a new string parameter
+    When I put parameter "/e2e/put-param-test" with value "test-value" and type "String"
+    Then the command will succeed
+    And parameter "/e2e/put-param-test" will have value "test-value"
+
+  @happy
+  Scenario: Put a parameter with a description
+    When I put parameter "/e2e/put-param-desc" with value "val" and type "String" and description "A test parameter"
+    Then the command will succeed
+    And parameter "/e2e/put-param-desc" will have value "val"
+
+  @happy
+  Scenario: Overwrite an existing parameter
+    Given a parameter "/e2e/put-param-ow" was created with value "v1" and type "String"
+    When I put parameter "/e2e/put-param-ow" with value "v2" and type "String" with overwrite
+    Then the command will succeed
+    And parameter "/e2e/put-param-ow" will have value "v2"

--- a/lang/specification/core/features/ssm/remove_tags_from_resource.feature
+++ b/lang/specification/core/features/ssm/remove_tags_from_resource.feature
@@ -1,0 +1,9 @@
+@ssm @remove_tags_from_resource @controlplane
+Feature: SSM RemoveTagsFromResource
+
+  @happy
+  Scenario: Remove tags from a parameter
+    Given a parameter "/e2e/remove-tags-test" was created with value "val1" and type "String"
+    And tags [{"Key": "env", "Value": "test"}] were added to parameter "/e2e/remove-tags-test"
+    When I remove tag keys ["env"] from parameter "/e2e/remove-tags-test"
+    Then the command will succeed

--- a/lang/specification/core/features/stepfunctions/create_state_machine.feature
+++ b/lang/specification/core/features/stepfunctions/create_state_machine.feature
@@ -1,0 +1,8 @@
+@stepfunctions @create_state_machine @controlplane
+Feature: StepFunctions CreateStateMachine
+
+  @happy
+  Scenario: Create a new state machine
+    When I create a state machine named "e2e-create-sm" with a Pass definition
+    Then the command will succeed
+    And state machine "e2e-create-sm" will exist

--- a/lang/specification/core/features/stepfunctions/delete_state_machine.feature
+++ b/lang/specification/core/features/stepfunctions/delete_state_machine.feature
@@ -1,0 +1,9 @@
+@stepfunctions @delete_state_machine @controlplane
+Feature: StepFunctions DeleteStateMachine
+
+  @happy
+  Scenario: Delete an existing state machine
+    Given a state machine "e2e-del-sm" was created with a Pass definition
+    When I delete state machine "e2e-del-sm"
+    Then the command will succeed
+    And state machine "e2e-del-sm" will not appear in list-state-machines

--- a/lang/specification/core/features/stepfunctions/describe_execution.feature
+++ b/lang/specification/core/features/stepfunctions/describe_execution.feature
@@ -1,0 +1,11 @@
+@stepfunctions @describe_execution @dataplane
+Feature: StepFunctions DescribeExecution
+
+  @happy
+  Scenario: Describe a running execution
+    Given a state machine "e2e-desc-exec" was created with a Pass definition
+    And an execution was started on state machine "e2e-desc-exec" with input "{}"
+    When I describe the started execution
+    Then the command will succeed
+    And the output will contain the execution ARN
+    And the output will contain a status field

--- a/lang/specification/core/features/stepfunctions/describe_state_machine.feature
+++ b/lang/specification/core/features/stepfunctions/describe_state_machine.feature
@@ -1,0 +1,9 @@
+@stepfunctions @describe_state_machine @controlplane
+Feature: StepFunctions DescribeStateMachine
+
+  @happy
+  Scenario: Describe an existing state machine
+    Given a state machine "e2e-desc-sm" was created with a Pass definition
+    When I describe state machine "e2e-desc-sm"
+    Then the command will succeed
+    And the output will contain state machine name "e2e-desc-sm"

--- a/lang/specification/core/features/stepfunctions/get_execution_history.feature
+++ b/lang/specification/core/features/stepfunctions/get_execution_history.feature
@@ -1,0 +1,9 @@
+@stepfunctions @get_execution_history @dataplane
+Feature: StepFunctions GetExecutionHistory
+
+  @happy
+  Scenario: Get execution history for an execution
+    Given a state machine "e2e-get-hist" was created with a Pass definition
+    And an execution was started on state machine "e2e-get-hist" with input "{}"
+    When I get execution history for the started execution
+    Then the command will succeed

--- a/lang/specification/core/features/stepfunctions/list_executions.feature
+++ b/lang/specification/core/features/stepfunctions/list_executions.feature
@@ -1,0 +1,10 @@
+@stepfunctions @list_executions @dataplane
+Feature: StepFunctions ListExecutions
+
+  @happy
+  Scenario: List executions for a state machine
+    Given a state machine "e2e-list-exec" was created with a Pass definition
+    And an execution was started on state machine "e2e-list-exec" with input "{}"
+    When I list executions for state machine "e2e-list-exec"
+    Then the command will succeed
+    And the executions list will have at least 1 entry

--- a/lang/specification/core/features/stepfunctions/list_state_machine_versions.feature
+++ b/lang/specification/core/features/stepfunctions/list_state_machine_versions.feature
@@ -1,0 +1,8 @@
+@stepfunctions @list_state_machine_versions @controlplane
+Feature: StepFunctions ListStateMachineVersions
+
+  @happy
+  Scenario: List versions of a state machine
+    Given a state machine "e2e-list-versions" was created with a Pass definition
+    When I list state machine versions for "e2e-list-versions"
+    Then the command will succeed

--- a/lang/specification/core/features/stepfunctions/list_state_machines.feature
+++ b/lang/specification/core/features/stepfunctions/list_state_machines.feature
@@ -1,0 +1,9 @@
+@stepfunctions @list_state_machines @controlplane
+Feature: StepFunctions ListStateMachines
+
+  @happy
+  Scenario: List state machines includes a created machine
+    Given a state machine "e2e-list-sm" was created with a Pass definition
+    When I list state machines
+    Then the command will succeed
+    And the state machine list will include "e2e-list-sm"

--- a/lang/specification/core/features/stepfunctions/list_tags_for_resource.feature
+++ b/lang/specification/core/features/stepfunctions/list_tags_for_resource.feature
@@ -1,0 +1,8 @@
+@stepfunctions @list_tags_for_resource @controlplane
+Feature: StepFunctions ListTagsForResource
+
+  @happy
+  Scenario: List tags for a state machine resource
+    Given a state machine "e2e-list-tags-sm" was created with a Pass definition
+    When I list tags for state machine "e2e-list-tags-sm"
+    Then the command will succeed

--- a/lang/specification/core/features/stepfunctions/start_execution.feature
+++ b/lang/specification/core/features/stepfunctions/start_execution.feature
@@ -1,0 +1,10 @@
+@stepfunctions @start_execution @dataplane
+Feature: StepFunctions StartExecution
+
+  @happy
+  Scenario: Start an execution on a state machine
+    Given a state machine "e2e-start-exec" was created with a Pass definition
+    When I start an execution on state machine "e2e-start-exec" with input '{"key": "value"}'
+    Then the command will succeed
+    And the output will contain an execution ARN
+    And the started execution will have a status

--- a/lang/specification/core/features/stepfunctions/start_sync_execution.feature
+++ b/lang/specification/core/features/stepfunctions/start_sync_execution.feature
@@ -1,0 +1,8 @@
+@stepfunctions @start_sync_execution @dataplane
+Feature: StepFunctions StartSyncExecution
+
+  @happy
+  Scenario: Start a synchronous execution on an EXPRESS state machine
+    Given an EXPRESS state machine "e2e-start-sync" was created with a Pass definition
+    When I start a sync execution on state machine "e2e-start-sync" with input "{}"
+    Then the command will succeed

--- a/lang/specification/core/features/stepfunctions/stop_execution.feature
+++ b/lang/specification/core/features/stepfunctions/stop_execution.feature
@@ -1,0 +1,10 @@
+@stepfunctions @stop_execution @dataplane
+Feature: StepFunctions StopExecution
+
+  @happy
+  Scenario: Stop a running execution
+    Given a state machine "e2e-stop-exec" was created with a Pass definition
+    And an execution was started on state machine "e2e-stop-exec" with input "{}"
+    When I stop the started execution
+    Then the command will succeed
+    And the stopped execution will have status "ABORTED"

--- a/lang/specification/core/features/stepfunctions/tag_resource.feature
+++ b/lang/specification/core/features/stepfunctions/tag_resource.feature
@@ -1,0 +1,9 @@
+@stepfunctions @tag_resource @controlplane
+Feature: StepFunctions TagResource
+
+  @happy
+  Scenario: Tag a state machine resource
+    Given a state machine "e2e-tag-sm" was created with a Pass definition
+    When I tag state machine "e2e-tag-sm" with tags [{"key": "env", "value": "test"}]
+    Then the command will succeed
+    And state machine "e2e-tag-sm" will have tag "env" with value "test"

--- a/lang/specification/core/features/stepfunctions/untag_resource.feature
+++ b/lang/specification/core/features/stepfunctions/untag_resource.feature
@@ -1,0 +1,10 @@
+@stepfunctions @untag_resource @controlplane
+Feature: StepFunctions UntagResource
+
+  @happy
+  Scenario: Untag a state machine resource
+    Given a state machine "e2e-untag-sm" was created with a Pass definition
+    And state machine "e2e-untag-sm" was tagged with tags [{"key": "env", "value": "test"}]
+    When I untag state machine "e2e-untag-sm" with tag keys ["env"]
+    Then the command will succeed
+    And state machine "e2e-untag-sm" will not have tag "env"

--- a/lang/specification/core/features/stepfunctions/update_state_machine.feature
+++ b/lang/specification/core/features/stepfunctions/update_state_machine.feature
@@ -1,0 +1,9 @@
+@stepfunctions @update_state_machine @controlplane
+Feature: StepFunctions UpdateStateMachine
+
+  @happy
+  Scenario: Update an existing state machine definition
+    Given a state machine "e2e-update-sm" was created with a Pass definition
+    When I update state machine "e2e-update-sm" with an updated definition
+    Then the command will succeed
+    And state machine "e2e-update-sm" will have the updated definition

--- a/lang/specification/core/features/stepfunctions/validate_state_machine_definition.feature
+++ b/lang/specification/core/features/stepfunctions/validate_state_machine_definition.feature
@@ -1,0 +1,7 @@
+@stepfunctions @validate_state_machine_definition @controlplane
+Feature: StepFunctions ValidateStateMachineDefinition
+
+  @happy
+  Scenario: Validate a valid state machine definition
+    When I validate a Pass state machine definition
+    Then the command will succeed

--- a/lang/specification/example/features/chaos.feature
+++ b/lang/specification/example/features/chaos.feature
@@ -1,0 +1,9 @@
+@stepfunctions @chaos @dataplane
+Feature: Chaos engineering injects errors into AWS calls
+
+  @error
+  Scenario: 100% error rate causes process order to fail
+    Given an OrderProcessor state machine is running
+    And stepfunctions chaos is set to 100% error rate
+    When I process order "order-chaos"
+    Then an AWS error is returned

--- a/lang/specification/example/features/dynamodb_helper.feature
+++ b/lang/specification/example/features/dynamodb_helper.feature
@@ -1,0 +1,9 @@
+@dynamodb @dynamodb_helper @dataplane
+Feature: DynamoDB helper seeds and asserts test data
+
+  @happy
+  Scenario: Seed an item and assert it exists
+    Given a DynamoDB table "Orders" with partition key "orderId"
+    When I put item with orderId "order-helper-001" and status "pending" into "Orders"
+    Then the table "Orders" will contain 1 item
+    And the table "Orders" will contain an item with orderId "order-helper-001"

--- a/lang/specification/example/features/fake.feature
+++ b/lang/specification/example/features/fake.feature
@@ -1,0 +1,25 @@
+@stepfunctions @fake @dataplane
+Feature: Fake Step Functions API calls
+
+  @happy
+  Scenario: Return a faked success response
+    Given no state machines are configured
+    And StartExecution is faked to return execution ARN "arn:aws:states:us-east-1:000000000000:execution:OrderProcessor:fake-exec"
+    And DescribeExecution is faked to return SUCCEEDED with output containing order ID "order-fake"
+    When I process order "order-fake" via ARN "arn:aws:states:us-east-1:000000000000:stateMachine:OrderProcessor"
+    Then the output will contain order ID "order-fake"
+
+  @error
+  Scenario: Propagate an injected AWS error from StartExecution
+    Given no state machines are configured
+    And StartExecution is faked to return error "ExecutionLimitExceeded"
+    When I process order "order-999" via ARN "arn:aws:states:us-east-1:000000000000:stateMachine:OrderProcessor"
+    Then an AWS error is returned
+
+  @happy
+  Scenario: Apply a response delay to StartExecution
+    Given no state machines are configured
+    And StartExecution is faked with a 10ms delay returning execution ARN "arn:aws:states:us-east-1:000000000000:execution:OrderProcessor:header-exec"
+    And DescribeExecution is faked to return SUCCEEDED with output containing order ID "order-header"
+    When I process order "order-header" via ARN "arn:aws:states:us-east-1:000000000000:stateMachine:OrderProcessor"
+    Then the output will contain order ID "order-header"

--- a/lang/specification/example/features/hcl_discovery.feature
+++ b/lang/specification/example/features/hcl_discovery.feature
@@ -1,0 +1,8 @@
+@stepfunctions @hcl_discovery @controlplane
+Feature: Discover state machines from Terraform HCL
+
+  @happy
+  Scenario: Load state machine definition from terraform directory
+    Given a session started from the "terraform" HCL directory
+    When I process order "order-tf"
+    Then the output will contain order ID "order-tf"

--- a/lang/specification/example/features/iam.feature
+++ b/lang/specification/example/features/iam.feature
@@ -1,0 +1,9 @@
+@iam @process_order @controlplane
+Feature: IAM enforce mode controls access to AWS operations
+
+  @happy
+  Scenario: Wildcard allow policy permits order processing
+    Given an OrderProcessor state machine is running
+    And IAM is in enforce mode with identity "test-user" allowed all actions on all resources
+    When I process order "order-iam-001"
+    Then the output will contain order ID "order-iam-001"

--- a/lang/specification/example/features/log_capture.feature
+++ b/lang/specification/example/features/log_capture.feature
@@ -1,0 +1,20 @@
+@stepfunctions @log_capture @dataplane
+Feature: Log capture records and filters AWS API calls
+
+  @happy
+  Scenario: Log capture records StartExecution call
+    Given an OrderProcessor state machine is running
+    And log capture is active
+    When I process order "order-logged"
+    Then the log capture will have recorded a "stepfunctions" "StartExecution" call
+    And no errors will appear in the log capture
+
+  @happy
+  Scenario: Log filtering returns entries by service and operation
+    Given an OrderProcessor state machine is running
+    When I process order "order-filter-001"
+    Then recent logs will be non-empty
+    When I start log capture and process order "order-filter-002"
+    Then the log capture will have recorded a "stepfunctions" "StartExecution" call
+    And filtering logs by service "stepfunctions" will return entries
+    And filtering logs by operation "StartExecution" will return entries

--- a/lang/specification/example/features/reset.feature
+++ b/lang/specification/example/features/reset.feature
@@ -1,0 +1,9 @@
+@stepfunctions @reset @controlplane
+Feature: Session reset clears runtime state
+
+  @happy
+  Scenario: Session remains functional after reset
+    Given an OrderProcessor state machine is running
+    And order "order-before-reset" has been processed
+    When I reset the session
+    Then the session accepts a second reset without error

--- a/lang/specification/example/features/run_state_machine.feature
+++ b/lang/specification/example/features/run_state_machine.feature
@@ -1,0 +1,20 @@
+@stepfunctions @process_order @dataplane
+Feature: Process an order through a Step Functions state machine
+
+  @happy
+  Scenario: Process a single order and receive output
+    Given an OrderProcessor state machine is running
+    When I process order "order-001"
+    Then the output will contain order ID "order-001"
+
+  @happy
+  Scenario: Process multiple orders sequentially
+    Given an OrderProcessor state machine is running
+    When I process orders "order-101", "order-102", "order-103"
+    Then each output will contain the corresponding order ID
+
+  @error
+  Scenario: Return an error for an unknown state machine ARN
+    Given no state machines are configured
+    When I process order "order-999" via ARN "arn:aws:states:us-east-1:000000000000:stateMachine:DoesNotExist"
+    Then an AWS error is returned

--- a/lang/specification/example/features/sqs_helper.feature
+++ b/lang/specification/example/features/sqs_helper.feature
@@ -1,0 +1,8 @@
+@sqs @sqs_helper @dataplane
+Feature: SQS helper sends and receives messages
+
+  @happy
+  Scenario: Send a message and receive it back
+    Given an SQS queue named "OrderQueue"
+    When I send message body "order-sqs-001" to "OrderQueue"
+    Then receiving 1 message from "OrderQueue" will return body "order-sqs-001"

--- a/lang/specification/sdk/features/cdk_discovery.feature
+++ b/lang/specification/sdk/features/cdk_discovery.feature
@@ -1,0 +1,8 @@
+@sdk @cdk_discovery
+Feature: CDK resource discovery
+
+  @happy
+  Scenario: Session started from CDK output directory has declared resources available
+    When I create a session from the "cdk.out" CDK directory
+    Then the session is running
+    And the resources declared in the CDK stack are available

--- a/lang/specification/sdk/features/chaos_injection.feature
+++ b/lang/specification/sdk/features/chaos_injection.feature
@@ -1,0 +1,26 @@
+@sdk @chaos_injection
+Feature: Chaos injection
+
+  @happy
+  Scenario: 100% error rate causes all calls to fail
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I set a 100% error rate on "stepfunctions"
+    And I call "stepfunctions" "StartExecution"
+    Then an AWS error is returned
+
+  @happy
+  Scenario: Clearing chaos restores normal behaviour
+    Given a running session with 100% error rate on "stepfunctions"
+    And an OrderProcessor state machine is running
+    When I clear chaos for "stepfunctions"
+    And I call "stepfunctions" "StartExecution"
+    Then the call succeeds
+
+  @happy
+  Scenario: Chaos applies only to the configured service
+    Given a running session
+    And a DynamoDB table "Orders" with partition key "orderId"
+    When I set a 100% error rate on "stepfunctions"
+    And I call "dynamodb" "ListTables"
+    Then the call succeeds

--- a/lang/specification/sdk/features/client_creation.feature
+++ b/lang/specification/sdk/features/client_creation.feature
@@ -1,0 +1,22 @@
+@sdk @client_creation
+Feature: AWS client creation
+
+  Clients returned by the session are pre-configured to point at the
+  local service endpoints — no manual endpoint or credential setup required.
+
+  @happy
+  Scenario Outline: Client for <service> is returned and usable
+    Given a running session
+    When I request a client for "<service>"
+    Then a configured client is returned
+    And the client can successfully call the <service> service
+
+    Examples:
+      | service          |
+      | dynamodb         |
+      | sqs              |
+      | s3               |
+      | sns              |
+      | stepfunctions    |
+      | ssm              |
+      | secretsmanager   |

--- a/lang/specification/sdk/features/dynamodb_helper.feature
+++ b/lang/specification/sdk/features/dynamodb_helper.feature
@@ -1,0 +1,21 @@
+@sdk @dynamodb_helper
+Feature: DynamoDB test helper
+
+  @happy
+  Scenario: Put an item and assert it exists
+    Given a running session with a DynamoDB table "Orders" with partition key "orderId"
+    When I put item with orderId "order-helper-001" and status "pending" into "Orders"
+    Then the table "Orders" will contain 1 item
+    And the table "Orders" will contain an item with orderId "order-helper-001"
+
+  @happy
+  Scenario: Item count assertion passes for the correct count
+    Given a running session with a DynamoDB table "Orders" with partition key "orderId"
+    When I put item with orderId "order-a" and status "pending" into "Orders"
+    And I put item with orderId "order-b" and status "pending" into "Orders"
+    Then the table "Orders" will contain 2 items
+
+  @happy
+  Scenario: Item existence assertion fails when item is absent
+    Given a running session with a DynamoDB table "Orders" with partition key "orderId"
+    Then the table "Orders" will not contain an item with orderId "order-missing"

--- a/lang/specification/sdk/features/fake_responses.feature
+++ b/lang/specification/sdk/features/fake_responses.feature
@@ -1,0 +1,38 @@
+@sdk @fake_responses
+Feature: Fake AWS API responses
+
+  @happy
+  Scenario: Fake a successful response for an operation
+    Given a running session
+    When I configure a fake success response for "stepfunctions" "StartExecution"
+    And I call "stepfunctions" "StartExecution"
+    Then the faked response body is returned
+
+  @happy
+  Scenario: Fake an error response for an operation
+    Given a running session
+    When I configure a fake error "ExecutionLimitExceeded" for "stepfunctions" "StartExecution"
+    And I call "stepfunctions" "StartExecution"
+    Then an AWS error "ExecutionLimitExceeded" is returned
+
+  @happy
+  Scenario: Fake a response with a delay
+    Given a running session
+    When I configure a fake success response for "stepfunctions" "StartExecution" with a 50ms delay
+    And I call "stepfunctions" "StartExecution"
+    Then the faked response body is returned
+
+  @happy
+  Scenario: Clearing fakes restores normal behaviour
+    Given a running session with a fake success response on "stepfunctions" "StartExecution"
+    When I clear fakes for "stepfunctions"
+    And I call "stepfunctions" "StartExecution" against a real state machine
+    Then the real response is returned
+
+  @happy
+  Scenario: Fake only intercepts the configured operation, others pass through
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I configure a fake success response for "stepfunctions" "StartExecution"
+    And I call "stepfunctions" "ListStateMachines"
+    Then the real response is returned

--- a/lang/specification/sdk/features/hcl_discovery.feature
+++ b/lang/specification/sdk/features/hcl_discovery.feature
@@ -1,0 +1,8 @@
+@sdk @hcl_discovery
+Feature: HCL resource discovery
+
+  @happy
+  Scenario: Session started from HCL directory has declared resources available
+    When I create a session from the "terraform" HCL directory
+    Then the session is running
+    And the resources declared in the HCL are available

--- a/lang/specification/sdk/features/iam_enforce.feature
+++ b/lang/specification/sdk/features/iam_enforce.feature
@@ -1,0 +1,26 @@
+@sdk @iam_enforce
+Feature: IAM enforce mode
+
+  @happy
+  Scenario: Wildcard allow policy permits calls
+    Given a running session
+    And an OrderProcessor state machine is running
+    And IAM is in enforce mode with identity "test-user" allowed all "states:*" actions
+    When I call "stepfunctions" "StartExecution"
+    Then the call succeeds
+
+  @error
+  Scenario: No matching policy denies the call in enforce mode
+    Given a running session
+    And an OrderProcessor state machine is running
+    And IAM is in enforce mode with identity "test-user" and no permissions
+    When I call "stepfunctions" "StartExecution"
+    Then an IAM access denied error is returned
+
+  @happy
+  Scenario: Returning to disabled mode allows all calls again
+    Given a running session with IAM enforce mode active
+    And an OrderProcessor state machine is running
+    When I set IAM mode to "disabled"
+    And I call "stepfunctions" "StartExecution"
+    Then the call succeeds

--- a/lang/specification/sdk/features/log_capture.feature
+++ b/lang/specification/sdk/features/log_capture.feature
@@ -1,0 +1,46 @@
+@sdk @log_capture
+Feature: Log capture
+
+  @happy
+  Scenario: Log capture records a call made within the capture window
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I start log capture and call "stepfunctions" "StartExecution"
+    Then the log capture will contain a "stepfunctions" "StartExecution" entry
+
+  @happy
+  Scenario: Log capture reports no errors when all calls succeed
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I start log capture and call "stepfunctions" "StartExecution"
+    Then no errors will appear in the log capture
+
+  @happy
+  Scenario: Log capture can be filtered by service
+    Given a running session
+    And an OrderProcessor state machine is running
+    And a DynamoDB table "Orders" with partition key "orderId"
+    When I start log capture and call both "stepfunctions" "StartExecution" and "dynamodb" "ListTables"
+    Then filtering by service "stepfunctions" returns only stepfunctions entries
+    And filtering by service "dynamodb" returns only dynamodb entries
+
+  @happy
+  Scenario: Log capture can be filtered by operation
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I start log capture and call "stepfunctions" "StartExecution"
+    Then filtering by operation "StartExecution" returns at least one entry
+
+  @happy
+  Scenario: Log capture call count assertion passes for the expected count
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I start log capture and call "stepfunctions" "StartExecution" twice
+    Then the log capture will contain exactly 2 "stepfunctions" "StartExecution" entries
+
+  @happy
+  Scenario: Recent logs returns entries from the whole session
+    Given a running session
+    And an OrderProcessor state machine is running
+    When I call "stepfunctions" "StartExecution"
+    Then recent logs are non-empty

--- a/lang/specification/sdk/features/resource_specification.feature
+++ b/lang/specification/sdk/features/resource_specification.feature
@@ -1,0 +1,39 @@
+@sdk @resource_specification
+Feature: Resource specification
+
+  Resources declared in the session spec are available immediately after
+  the session starts — no separate creation step is needed in tests.
+
+  @happy
+  Scenario: DynamoDB table declared in spec is available on start
+    Given a session with a DynamoDB table "Orders" with partition key "orderId"
+    Then the table "Orders" exists
+
+  @happy
+  Scenario: SQS queue declared in spec is available on start
+    Given a session with an SQS queue "OrderQueue"
+    Then the queue "OrderQueue" exists
+
+  @happy
+  Scenario: S3 bucket declared in spec is available on start
+    Given a session with an S3 bucket "order-bucket"
+    Then the bucket "order-bucket" exists
+
+  @happy
+  Scenario: SNS topic declared in spec is available on start
+    Given a session with an SNS topic "OrderEvents"
+    Then the topic "OrderEvents" exists
+
+  @happy
+  Scenario: Step Functions state machine declared in spec is available on start
+    Given a session with a state machine "OrderProcessor" using a Pass definition
+    Then the state machine "OrderProcessor" exists
+
+  @happy
+  Scenario: Multiple resource types declared together are all available on start
+    Given a session with a DynamoDB table "Orders" with partition key "orderId"
+    And the session also has an SQS queue "OrderQueue"
+    And the session also has an S3 bucket "order-bucket"
+    Then the table "Orders" exists
+    And the queue "OrderQueue" exists
+    And the bucket "order-bucket" exists

--- a/lang/specification/sdk/features/session_lifecycle.feature
+++ b/lang/specification/sdk/features/session_lifecycle.feature
@@ -1,0 +1,15 @@
+@sdk @session_lifecycle
+Feature: Session lifecycle
+
+  @happy
+  Scenario: Create a session with default options and close it
+    When I create a session
+    Then the session is running
+    When I close the session
+    Then the session is closed
+
+  @happy
+  Scenario: Session can be used as a context manager
+    When I open a session as a context manager
+    Then the session is running inside the context
+    And the session is closed after the context exits

--- a/lang/specification/sdk/features/session_reset.feature
+++ b/lang/specification/sdk/features/session_reset.feature
@@ -1,0 +1,26 @@
+@sdk @session_reset
+Feature: Session reset
+
+  Reset clears all runtime state (stored data, fakes, chaos, IAM config)
+  without restarting the underlying services.
+
+  @happy
+  Scenario: Reset can be called multiple times without error
+    Given a running session
+    When I reset the session
+    And I reset the session again
+    Then no error is raised
+
+  @happy
+  Scenario: Reset clears DynamoDB table data
+    Given a running session with a DynamoDB table "Orders" with partition key "orderId"
+    And an item with orderId "order-001" has been put into "Orders"
+    When I reset the session
+    Then the table "Orders" contains 0 items
+
+  @happy
+  Scenario: Reset clears SQS queue messages
+    Given a running session with an SQS queue "OrderQueue"
+    And a message has been sent to "OrderQueue"
+    When I reset the session
+    Then "OrderQueue" contains 0 messages

--- a/lang/specification/sdk/features/sqs_helper.feature
+++ b/lang/specification/sdk/features/sqs_helper.feature
@@ -1,0 +1,16 @@
+@sdk @sqs_helper
+Feature: SQS test helper
+
+  @happy
+  Scenario: Send a message and receive it back
+    Given a running session with an SQS queue "OrderQueue"
+    When I send message body "order-sqs-001" to "OrderQueue"
+    Then receiving 1 message from "OrderQueue" returns body "order-sqs-001"
+
+  @happy
+  Scenario: Receive respects the requested max message count
+    Given a running session with an SQS queue "OrderQueue"
+    And I send message body "msg-1" to "OrderQueue"
+    And I send message body "msg-2" to "OrderQueue"
+    When I receive 1 message from "OrderQueue"
+    Then exactly 1 message is returned


### PR DESCRIPTION
## Summary

Adds \`lang/specification/\` — a new language-agnostic directory that mirrors the structure of the other \`lang/\` directories (\`core/\`, \`example/\`, \`sdk/\` each with a \`features/\` subdirectory). These feature files become the canonical specification that all SDK implementations must satisfy.

| Directory | Source | Count |
|-----------|--------|-------|
| \`specification/core/features/<service>/\` | Copied from \`core/tests/e2e/\` | 278 files |
| \`specification/example/features/\` | Copied from \`lang/go/example/features/\` | 9 files |
| \`specification/sdk/features/\` | New — describes SDK behaviour | 12 files |

### SDK feature files (new)

| File | Covers |
|------|--------|
| \`session_lifecycle\` | Create/close a session, context manager usage |
| \`resource_specification\` | Tables, queues, buckets, topics, state machines declared in spec |
| \`client_creation\` | AWS client returned per service |
| \`fake_responses\` | Fake success/error/delayed responses, fallthrough, clear |
| \`chaos_injection\` | Error rate injection, clear, service isolation |
| \`iam_enforce\` | Allow policy, deny policy, return to disabled mode |
| \`log_capture\` | Record calls, filter by service/operation, call count, recent logs |
| \`session_reset\` | Multiple resets, clears DynamoDB data, clears SQS messages |
| \`dynamodb_helper\` | Put, count assertion, existence assertion |
| \`sqs_helper\` | Send/receive, max message count |
| \`hcl_discovery\` | Session from Terraform HCL directory |
| \`cdk_discovery\` | Session from CDK output directory |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)