### PR TITLE
Thread --seed through to Terraform mode organizations provider

### DIFF
--- a/lang/python/core/src/lws/cli/_ldk_provider_factory.py
+++ b/lang/python/core/src/lws/cli/_ldk_provider_factory.py
@@ -34,9 +34,9 @@ from lws.cli._ldk_providers_core import (  # noqa: F401  # pylint: disable=unuse
 )
 from lws.cli._ldk_providers_extended import (  # noqa: F401  # pylint: disable=unused-import
     _register_experimental_providers,
-    _register_organizations_provider,
     _register_simple_providers,
     _register_ssm_secretsmanager_providers,
+    _wire_organizations_provider,
 )
 from lws.config.loader import LdkConfig
 from lws.graph.builder import AppGraph
@@ -310,12 +310,8 @@ def _create_providers(  # pylint: disable=too-many-statements
     )
 
     # 12. Organizations
-    _register_organizations_provider(
-        providers,
-        chaos_configs=chaos_configs,
-        aws_fake_configs=aws_fake_configs,
-        organizations_port=ports["organizations"],
-        organizations_seed=organizations_seed,
+    _wire_organizations_provider(
+        providers, ports, chaos_configs, aws_fake_configs, organizations_seed
     )
 
     # 13. Auto-discovered simple services (cloudformation, servicecatalog, sts, etc.)

--- a/lang/python/core/src/lws/cli/_ldk_providers_extended.py
+++ b/lang/python/core/src/lws/cli/_ldk_providers_extended.py
@@ -112,6 +112,23 @@ def _register_organizations_provider(
     )
 
 
+def _wire_organizations_provider(
+    providers: dict,
+    ports: dict,
+    chaos_configs: dict,
+    aws_fake_configs: dict,
+    organizations_seed: str | None = None,
+) -> None:
+    """Register the Organizations provider using a ports mapping."""
+    _register_organizations_provider(
+        providers,
+        chaos_configs=chaos_configs,
+        aws_fake_configs=aws_fake_configs,
+        organizations_port=ports["organizations"],
+        organizations_seed=organizations_seed,
+    )
+
+
 def _register_cloudtrail_provider(
     providers: dict,
     *,

--- a/lang/python/core/src/lws/cli/_ldk_server.py
+++ b/lang/python/core/src/lws/cli/_ldk_server.py
@@ -31,8 +31,8 @@ from lws.cli._ldk_provider_factory import (
     _register_fake_provider,
 )
 from lws.cli._ldk_providers_extended import (
-    _register_organizations_provider,
     _register_simple_providers,
+    _wire_organizations_provider,
 )
 from lws.cli._ldk_resource_metadata import _build_resource_metadata, _service_ports
 from lws.cli.display import print_error
@@ -61,6 +61,7 @@ def _create_terraform_providers(
     project_dir: Path | None = None,
     iam_auth_bundle: IamAuthBundle | None = None,
     registry: TrackerRegistry | None = None,
+    organizations_seed: str | None = None,
 ) -> tuple[
     dict[str, Provider],
     dict[str, int],
@@ -161,11 +162,8 @@ def _create_terraform_providers(
     providers["__sts_http__"] = _HttpServiceProvider("sts-http", create_sts_app, ports["sts"])
 
     # Organizations
-    _register_organizations_provider(
-        providers,
-        chaos_configs=chaos_configs,
-        aws_fake_configs=aws_fake_configs,
-        organizations_port=ports["organizations"],
+    _wire_organizations_provider(
+        providers, ports, chaos_configs, aws_fake_configs, organizations_seed
     )
 
     # Auto-discovered simple services (cloudformation, servicecatalog, sts, etc.)
@@ -212,7 +210,7 @@ def _create_terraform_providers(
     return providers, ports, chaos_configs, aws_fake_configs, lifecycle_configs
 
 
-async def _run_dev_terraform(project_dir: Path, config: LdkConfig) -> None:
+async def _run_dev_terraform(project_dir: Path, config: LdkConfig, seed: str | None = None) -> None:
     """Run the dev server in Terraform mode.
 
     Starts all service providers in always-on mode, generates the
@@ -254,6 +252,7 @@ async def _run_dev_terraform(project_dir: Path, config: LdkConfig) -> None:
             project_dir,
             iam_auth_bundle=iam_auth_bundle,
             registry=tracker_registry,
+            organizations_seed=seed,
         )
     )
 
@@ -383,7 +382,7 @@ async def _run_dev(
     # Resolve project mode
     resolved_mode = _resolve_mode(project_dir, config, mode_override)
     if resolved_mode == "terraform":
-        await _run_dev_terraform(project_dir, config)
+        await _run_dev_terraform(project_dir, config, seed=seed)
         return
 
     try:

--- a/lang/python/core/tests/unit/cli/test_create_terraform_providers.py
+++ b/lang/python/core/tests/unit/cli/test_create_terraform_providers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from lws.config.loader import LdkConfig
 
 
@@ -92,3 +94,39 @@ class TestCreateTerraformProviders:
         assert (
             ports["sts"] == expected_sts_port
         ), f'Expected {expected_sts_port!r} but got {ports["sts"]!r}'
+
+    def test_organizations_seed_forwarded_to_provider(self, tmp_path) -> None:
+        from lws.cli.ldk import _create_terraform_providers
+
+        # Arrange
+        expected_seed = "my-org-seed"
+        config = LdkConfig(port=5000)
+        target = "lws.cli._ldk_providers_extended._register_organizations_provider"
+
+        # Act
+        with patch(target) as mock_register:
+            _create_terraform_providers(config, tmp_path, organizations_seed=expected_seed)
+
+        # Assert
+        actual_seed = mock_register.call_args.kwargs.get("organizations_seed")
+        assert (
+            actual_seed == expected_seed
+        ), f"Expected organizations_seed={expected_seed!r} but got {actual_seed!r}"
+
+    def test_organizations_seed_defaults_to_none(self, tmp_path) -> None:
+        from lws.cli.ldk import _create_terraform_providers
+
+        # Arrange
+        expected_seed = None
+        config = LdkConfig(port=6000)
+        target = "lws.cli._ldk_providers_extended._register_organizations_provider"
+
+        # Act
+        with patch(target) as mock_register:
+            _create_terraform_providers(config, tmp_path)
+
+        # Assert
+        actual_seed = mock_register.call_args.kwargs.get("organizations_seed")
+        assert (
+            actual_seed == expected_seed
+        ), f"Expected organizations_seed={expected_seed!r} but got {actual_seed!r}"


### PR DESCRIPTION
## Summary

- `--seed` was silently ignored in Terraform mode: `_run_dev` returned early after calling `_run_dev_terraform(project_dir, config)` before `seed` was ever used
- Threads `seed` through `_run_dev_terraform` → `_create_terraform_providers` → `_register_organizations_provider`, mirroring the existing CDK path
- Extracts `_wire_organizations_provider` helper to eliminate the CPD hit from the now-identical call sites in both provider creation paths

## Test plan

- [ ] Run `ldk dev --seed <path>` in Terraform mode and verify the organizations provider loads the seed data
- [ ] Run `make -C lang/python/core lint` — CPD should report `duplicates=0`
- [ ] Run `make -C lang/python/core test-unit` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)