### PR TITLE
Fix DynamoDB FilterExpression on Scan always returning zero items

### DIFF
--- a/lang/python/core/src/lws/providers/dynamodb/expressions.py
+++ b/lang/python/core/src/lws/providers/dynamodb/expressions.py
@@ -299,11 +299,11 @@ class ExpressionEvaluator:
         ref = node["ref"]
         real_name = self._names.get(ref, ref)
         found, val = _resolve_path(item, real_name)
-        return val if found else None
+        return _unwrap_dynamo_value(val) if found else None
 
     def _eval_path(self, node: dict, item: dict) -> Any:
         found, val = _resolve_path(item, node["path"])
-        return val if found else None
+        return _unwrap_dynamo_value(val) if found else None
 
     def _eval_literal(self, node: dict, _item: dict) -> Any:
         return node["value"]

--- a/lang/python/core/tests/integration/dynamodb/client.py
+++ b/lang/python/core/tests/integration/dynamodb/client.py
@@ -77,3 +77,26 @@ class DynamodbTestClient:
                 },
             },
         )
+
+    def put_items_with_different_statuses(self, name: str = TEST_TABLE) -> None:
+        self.post(
+            "PutItem",
+            {"TableName": name, "Item": {TEST_PK: {"S": "item-1"}, "status": {"S": "active"}}},
+        )
+        self.post(
+            "PutItem",
+            {
+                "TableName": name,
+                "Item": {TEST_PK: {"S": "item-2"}, "status": {"S": "inactive"}},
+            },
+        )
+
+    def scan_with_filter(self, name: str = TEST_TABLE) -> TestClient:
+        return self.post(
+            "Scan",
+            {
+                "TableName": name,
+                "FilterExpression": "status = :s",
+                "ExpressionAttributeValues": {":s": {"S": "active"}},
+            },
+        )

--- a/lang/python/core/tests/integration/dynamodb/given/__init__.py
+++ b/lang/python/core/tests/integration/dynamodb/given/__init__.py
@@ -8,6 +8,7 @@ from .item_exists import *  # noqa: F401,F403
 from .item_exists_in_table import *  # noqa: F401,F403
 from .item_is_not_present import *  # noqa: F401,F403
 from .item_is_present import *  # noqa: F401,F403
+from .items_with_different_attribute_values import *  # noqa: F401,F403
 from .no_transaction_in_progress import *  # noqa: F401,F403
 from .no_transaction_is_pending import *  # noqa: F401,F403
 from .reads_not_throttled import *  # noqa: F401,F403

--- a/lang/python/core/tests/integration/dynamodb/given/items_with_different_attribute_values.py
+++ b/lang/python/core/tests/integration/dynamodb/given/items_with_different_attribute_values.py
@@ -1,0 +1,15 @@
+"""Given: multiple "dynamodb" "item"s with different attribute values existed in the "dynamodb" "table" """
+
+from __future__ import annotations
+
+from pytest_bdd import given
+from starlette.testclient import TestClient
+
+from ..client import DynamodbTestClient
+
+
+@given(
+    'multiple "dynamodb" "item"s with different attribute values existed in the "dynamodb" "table"'
+)
+def items_with_different_attribute_values(client: TestClient):
+    DynamodbTestClient(client).put_items_with_different_statuses()

--- a/lang/python/core/tests/integration/dynamodb/then/__init__.py
+++ b/lang/python/core/tests/integration/dynamodb/then/__init__.py
@@ -16,6 +16,7 @@ from .items_only_in_non_deleted_tables import *  # noqa: F401,F403
 from .list_of_tables_returned_then import *  # noqa: F401,F403
 from .matching_items_returned_from_gsi import *  # noqa: F401,F403
 from .matching_items_returned_then import *  # noqa: F401,F403
+from .only_matching_items_returned_then import *  # noqa: F401,F403
 from .pending_transaction_references_existing_table import *  # noqa: F401,F403
 from .query_results_contain_item_then import *  # noqa: F401,F403
 from .reads_are_throttled_then import *  # noqa: F401,F403

--- a/lang/python/core/tests/integration/dynamodb/then/only_matching_items_returned_then.py
+++ b/lang/python/core/tests/integration/dynamodb/then/only_matching_items_returned_then.py
@@ -1,0 +1,16 @@
+"""Then: only "dynamodb" "item"s matching the filter expression will be returned"""
+
+from __future__ import annotations
+
+from pytest_bdd import then
+
+
+@then('only "dynamodb" "item"s matching the filter expression will be returned')
+def only_matching_items_returned_then(world: dict):
+    expected_count = 1
+    actual_result = world["result"]
+    actual_items = actual_result.get("Items", []) if actual_result else []
+    actual_count = len(actual_items)
+    assert (
+        actual_count == expected_count
+    ), f"Expected {expected_count!r} items but got {actual_count!r}: {actual_items!r}"

--- a/lang/python/core/tests/integration/dynamodb/when/__init__.py
+++ b/lang/python/core/tests/integration/dynamodb/when/__init__.py
@@ -20,6 +20,7 @@ from .query_table import *  # noqa: F401,F403
 from .resolve_pending_transaction import *  # noqa: F401,F403
 from .rollback_transaction import *  # noqa: F401,F403
 from .scan_table import *  # noqa: F401,F403
+from .scan_table_with_filter import *  # noqa: F401,F403
 from .set_throttle_reads import *  # noqa: F401,F403
 from .set_throttle_writes import *  # noqa: F401,F403
 from .toggle_read_throttling import *  # noqa: F401,F403

--- a/lang/python/core/tests/integration/dynamodb/when/scan_table_with_filter.py
+++ b/lang/python/core/tests/integration/dynamodb/when/scan_table_with_filter.py
@@ -1,0 +1,15 @@
+"""When: all "dynamodb" "item"s in the "dynamodb" "table" are scanned with a filter expression"""
+
+from __future__ import annotations
+
+from pytest_bdd import when
+from starlette.testclient import TestClient
+
+from ..client import DynamodbTestClient
+from ..constants import TEST_TABLE, _store
+
+
+@when('all "dynamodb" "item"s in the "dynamodb" "table" are scanned with a filter expression')
+def scan_table_with_filter(client: TestClient, world: dict):
+    r = DynamodbTestClient(client).scan_with_filter(TEST_TABLE)
+    _store(world, r)

--- a/lang/python/core/tests/unit/providers/test_dynamodb_expressions_comparison_operators_dynamo_json.py
+++ b/lang/python/core/tests/unit/providers/test_dynamodb_expressions_comparison_operators_dynamo_json.py
@@ -1,0 +1,59 @@
+"""Tests for DynamoDB FilterExpression evaluator (P1-23)."""
+
+from __future__ import annotations
+
+from lws.providers.dynamodb.expressions import (
+    evaluate_filter_expression,
+)
+
+
+class TestDynamoJsonItemComparisons:
+    """Comparison operators against items in DynamoDB JSON format (as stored in SQLite)."""
+
+    def test_string_equality_on_dynamo_json_item(self) -> None:
+        # Arrange
+        item = {"status": {"S": "active"}}
+        expression = "status = :v"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":v": {"S": "active"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"
+
+    def test_numeric_comparison_on_dynamo_json_item(self) -> None:
+        # Arrange
+        item = {"score": {"N": "42"}}
+        expression = "score > :min"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":min": {"N": "10"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"
+
+    def test_string_equality_non_matching_on_dynamo_json_item(self) -> None:
+        # Arrange
+        item = {"status": {"S": "inactive"}}
+        expression = "status = :v"
+        expected_result = False
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":v": {"S": "active"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"

--- a/lang/python/core/tests/unit/providers/test_dynamodb_expressions_expression_resolution_dynamo_json.py
+++ b/lang/python/core/tests/unit/providers/test_dynamodb_expressions_expression_resolution_dynamo_json.py
@@ -1,0 +1,46 @@
+"""Tests for DynamoDB FilterExpression evaluator (P1-23)."""
+
+from __future__ import annotations
+
+from lws.providers.dynamodb.expressions import (
+    evaluate_filter_expression,
+)
+
+
+class TestDynamoJsonItemResolution:
+    """Name and value resolution against items in DynamoDB JSON format (as stored in SQLite)."""
+
+    def test_name_ref_resolves_dynamo_json_string_attribute(self) -> None:
+        # Arrange
+        item = {"status": {"S": "active"}}
+        expression = "#s = :v"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item,
+            expression,
+            expression_names={"#s": "status"},
+            expression_values={":v": {"S": "active"}},
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"
+
+    def test_path_resolves_dynamo_json_numeric_attribute(self) -> None:
+        # Arrange
+        item = {"count": {"N": "7"}}
+        expression = "count = :v"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":v": {"N": "7"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"

--- a/lang/python/core/tests/unit/providers/test_dynamodb_expressions_functions_dynamo_json.py
+++ b/lang/python/core/tests/unit/providers/test_dynamodb_expressions_functions_dynamo_json.py
@@ -1,0 +1,43 @@
+"""Tests for DynamoDB FilterExpression evaluator (P1-23)."""
+
+from __future__ import annotations
+
+from lws.providers.dynamodb.expressions import (
+    evaluate_filter_expression,
+)
+
+
+class TestDynamoJsonItemFunctions:
+    """Built-in functions against items in DynamoDB JSON format (as stored in SQLite)."""
+
+    def test_begins_with_dynamo_json_string(self) -> None:
+        # Arrange
+        item = {"name": {"S": "Alice"}}
+        expression = "begins_with(name, :prefix)"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":prefix": {"S": "Al"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"
+
+    def test_contains_dynamo_json_string(self) -> None:
+        # Arrange
+        item = {"description": {"S": "hello world"}}
+        expression = "contains(description, :sub)"
+        expected_result = True
+
+        # Act
+        actual_result = evaluate_filter_expression(
+            item, expression, expression_values={":sub": {"S": "world"}}
+        )
+
+        # Assert
+        assert (
+            actual_result == expected_result
+        ), f"Expected {expected_result!r} but got {actual_result!r}"

--- a/lang/python/core/tests/unit/providers/test_dynamodb_provider_query.py
+++ b/lang/python/core/tests/unit/providers/test_dynamodb_provider_query.py
@@ -226,6 +226,38 @@ class TestQuery:
             actual_status == expected_status
         ), f"Expected {expected_status!r} but got {actual_status!r}"
 
+    async def test_query_with_filter_expression_returns_matching_items(
+        self, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange — items in DynamoDB JSON format, as stored via the HTTP route
+        await provider.put_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}, "status": {"S": "active"}},
+        )
+        await provider.put_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i2"}, "status": {"S": "inactive"}},
+        )
+        expected_count = 1
+        expected_status = {"S": "active"}
+
+        # Act
+        results = await provider.query(
+            "orders",
+            "orderId = :pk",
+            expression_values={":pk": {"S": "o1"}, ":s": {"S": "active"}},
+            filter_expression="status = :s",
+        )
+
+        # Assert
+        assert (
+            len(results) == expected_count
+        ), f"Expected {expected_count!r} but got {len(results)!r}"
+        actual_status = results[0]["status"]
+        assert (
+            actual_status == expected_status
+        ), f"Expected {expected_status!r} but got {actual_status!r}"
+
     async def test_query_sk_gt(self, provider: SqliteDynamoProvider) -> None:
         # Arrange
         await provider.put_item("orders", {"orderId": "o1", "itemId": "a"})

--- a/lang/python/core/tests/unit/providers/test_dynamodb_provider_scan.py
+++ b/lang/python/core/tests/unit/providers/test_dynamodb_provider_scan.py
@@ -150,3 +150,34 @@ class TestScan:
         assert (
             actual_status == expected_status
         ), f"Expected {expected_status!r} but got {actual_status!r}"
+
+    async def test_scan_with_filter_expression_returns_matching_items(
+        self, provider: SqliteDynamoProvider
+    ) -> None:
+        # Arrange — items in DynamoDB JSON format, as stored via the HTTP route
+        await provider.put_item(
+            "orders",
+            {"orderId": {"S": "o1"}, "itemId": {"S": "i1"}, "status": {"S": "active"}},
+        )
+        await provider.put_item(
+            "orders",
+            {"orderId": {"S": "o2"}, "itemId": {"S": "i2"}, "status": {"S": "inactive"}},
+        )
+        expected_count = 1
+        expected_status = {"S": "active"}
+
+        # Act
+        results = await provider.scan(
+            "orders",
+            filter_expression="status = :s",
+            expression_values={":s": {"S": "active"}},
+        )
+
+        # Assert
+        assert (
+            len(results) == expected_count
+        ), f"Expected {expected_count!r} but got {len(results)!r}"
+        actual_status = results[0]["status"]
+        assert (
+            actual_status == expected_status
+        ), f"Expected {expected_status!r} but got {actual_status!r}"

--- a/lang/python/sdk/tests/e2e/dynamodb/client.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/client.py
@@ -83,3 +83,20 @@ class DynamodbTestClient:
             ExpressionAttributeNames={"#gsi_pk": GSI_PK},
             ExpressionAttributeValues={":gsi_val": {"S": GSI_PK_VALUE}},
         )
+
+    def put_items_with_different_statuses(self, name=TEST_TABLE):
+        self._client.put_item(
+            TableName=name,
+            Item={TEST_PK: {"S": "item-1"}, "status": {"S": "active"}},
+        )
+        self._client.put_item(
+            TableName=name,
+            Item={TEST_PK: {"S": "item-2"}, "status": {"S": "inactive"}},
+        )
+
+    def scan_with_filter(self, name=TEST_TABLE):
+        return self._client.scan(
+            TableName=name,
+            FilterExpression="status = :s",
+            ExpressionAttributeValues={":s": {"S": "active"}},
+        )

--- a/lang/python/sdk/tests/e2e/dynamodb/given/__init__.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/given/__init__.py
@@ -35,6 +35,7 @@ from .item_exists import *  # noqa: F401,F403
 from .item_exists_in_table import *  # noqa: F401,F403
 from .item_is_not_present import *  # noqa: F401,F403
 from .item_is_present import *  # noqa: F401,F403
+from .items_with_different_attribute_values import *  # noqa: F401,F403
 from .no_transaction_in_progress import *  # noqa: F401,F403
 from .no_transaction_is_pending import *  # noqa: F401,F403
 from .reads_not_throttled import *  # noqa: F401,F403

--- a/lang/python/sdk/tests/e2e/dynamodb/given/items_with_different_attribute_values.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/given/items_with_different_attribute_values.py
@@ -1,0 +1,14 @@
+"""Given: multiple "dynamodb" "item"s with different attribute values existed in the "dynamodb" "table" """
+
+from __future__ import annotations
+
+from pytest_bdd import given
+
+from ..client import DynamodbTestClient
+
+
+@given(
+    'multiple "dynamodb" "item"s with different attribute values existed in the "dynamodb" "table"'
+)
+def items_with_different_attribute_values(lws_session):
+    DynamodbTestClient(lws_session).put_items_with_different_statuses()

--- a/lang/python/sdk/tests/e2e/dynamodb/then/__init__.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/then/__init__.py
@@ -18,6 +18,7 @@ from .items_only_in_non_deleted_tables import *  # noqa: F401,F403
 from .list_of_tables_returned_then import *  # noqa: F401,F403
 from .matching_items_returned_from_gsi import *  # noqa: F401,F403
 from .matching_items_returned_then import *  # noqa: F401,F403
+from .only_matching_items_returned_then import *  # noqa: F401,F403
 from .pending_transaction_references_existing_table import *  # noqa: F401,F403
 from .query_results_contain_item_then import *  # noqa: F401,F403
 from .reads_are_throttled_then import *  # noqa: F401,F403

--- a/lang/python/sdk/tests/e2e/dynamodb/then/only_matching_items_returned_then.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/then/only_matching_items_returned_then.py
@@ -1,0 +1,16 @@
+"""Then: only "dynamodb" "item"s matching the filter expression will be returned"""
+
+from __future__ import annotations
+
+from pytest_bdd import then
+
+
+@then('only "dynamodb" "item"s matching the filter expression will be returned')
+def only_matching_items_returned_then(world: dict):
+    expected_count = 1
+    actual_result = world["result"]
+    actual_items = actual_result.get("Items", []) if actual_result else []
+    actual_count = len(actual_items)
+    assert (
+        actual_count == expected_count
+    ), f"Expected {expected_count!r} items but got {actual_count!r}: {actual_items!r}"

--- a/lang/python/sdk/tests/e2e/dynamodb/when/__init__.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/when/__init__.py
@@ -20,6 +20,7 @@ from .query_table import *  # noqa: F401,F403
 from .resolve_pending_transaction import *  # noqa: F401,F403
 from .rollback_transaction import *  # noqa: F401,F403
 from .scan_table import *  # noqa: F401,F403
+from .scan_table_with_filter import *  # noqa: F401,F403
 from .set_throttle_reads import *  # noqa: F401,F403
 from .set_throttle_writes import *  # noqa: F401,F403
 from .table_deletion_completes import *  # noqa: F401,F403

--- a/lang/python/sdk/tests/e2e/dynamodb/when/scan_table_with_filter.py
+++ b/lang/python/sdk/tests/e2e/dynamodb/when/scan_table_with_filter.py
@@ -1,0 +1,19 @@
+"""When: all "dynamodb" "item"s in the "dynamodb" "table" are scanned with a filter expression"""
+
+from __future__ import annotations
+
+from botocore.exceptions import ClientError
+from pytest_bdd import when
+
+from ..client import DynamodbTestClient
+from ..constants import TEST_TABLE
+
+
+@when('all "dynamodb" "item"s in the "dynamodb" "table" are scanned with a filter expression')
+def scan_table_with_filter(lws_session, world):
+    try:
+        world["result"] = DynamodbTestClient(lws_session).scan_with_filter(TEST_TABLE)
+        world["error"] = None
+    except (ClientError, Exception) as exc:
+        world["result"] = None
+        world["error"] = exc

--- a/lang/specification/core/informal/dynamodb/scan.feature
+++ b/lang/specification/core/informal/dynamodb/scan.feature
@@ -22,6 +22,15 @@ Feature: DYNAMODB - All "Dynamodb" "Item"S In The "Dynamodb" "Table" Are Scanned
     And "dynamodb" "item"s only exist in non-deleted "dynamodb" "table"s
     And deleted "dynamodb" "table"s are never the target of a pending "dynamodb" "transaction"
 
+  @minimal @happy @scan
+  Scenario: only matching "dynamodb" "item"s are returned when a filter expression is applied
+    Given the "dynamodb" "table" existed
+    And the "dynamodb" "table" was "ACTIVE"
+    And "dynamodb" "read" throttling was not active
+    And multiple "dynamodb" "item"s with different attribute values existed in the "dynamodb" "table"
+    When all "dynamodb" "item"s in the "dynamodb" "table" are scanned with a filter expression
+    Then only "dynamodb" "item"s matching the filter expression will be returned
+
   @guard @negative @scan
   Scenario: all "dynamodb" "item"s in the "dynamodb" "table" are scanned fails when the "dynamodb" "table" did not exist
     Given the "dynamodb" "table" did not exist

--- a/openspec/changes/fix-dynamodb-scan-filter-expression/proposal.md
+++ b/openspec/changes/fix-dynamodb-scan-filter-expression/proposal.md
@@ -1,0 +1,55 @@
+# Change: Fix DynamoDB Scan FilterExpression Always Returns Empty
+
+## Status
+
+Draft
+
+## Problem
+
+`Scan` with a `FilterExpression` (e.g. `Attr('x').eq('y')`) always returns
+`Count=0` regardless of what is in the table. The same defect also affects
+`Query` when a `FilterExpression` accompanies the key condition.
+
+### Root cause
+
+`apply_filter_expression` was written and unit-tested with plain Python dicts
+(e.g. `{"x": "y"}`). In practice the provider passes it items fetched directly
+from SQLite, which are serialised in **DynamoDB JSON format**:
+
+```json
+{"x": {"S": "y"}, "pk": {"S": "key"}}
+```
+
+Inside `ExpressionEvaluator`, `_eval_value_ref` correctly unwraps typed values
+via `_unwrap_dynamo_value` (so `:val` resolves to `"y"`), but `_eval_path` and
+`_eval_name_ref` return the raw DynamoDB dict `{"S": "y"}` unchanged. The
+equality check `{"S": "y"} == "y"` is always `False`, so every item is filtered
+out.
+
+The same code path executes for all comparison operators, `BETWEEN`, `IN`, and
+string/list functions (`begins_with`, `contains`, `size`).
+
+## Proposed Fix
+
+In `expressions.py`, apply `_unwrap_dynamo_value` to the value returned by
+`_eval_path` and `_eval_name_ref` before returning it to the evaluator. This
+makes attribute resolution symmetric with value-ref resolution.
+
+No changes are needed in `routes.py` or `provider.py`; the fix is entirely
+contained within the expression evaluator.
+
+## Scope
+
+| File | Change |
+|---|---|
+| `expressions.py` | `_eval_path` and `_eval_name_ref` unwrap DynamoDB typed values |
+| `test_dynamodb_expressions_*.py` | Add DynamoDB-JSON-format items to existing expression tests |
+| `test_dynamodb_provider_scan.py` | Add FilterExpression scenario |
+| `test_dynamodb_provider_query.py` | Add FilterExpression scenario |
+| `scan.feature` | Add `@minimal` filtered-scan scenario |
+
+## Out of Scope
+
+- `ProjectionExpression` support
+- Nested attribute paths (dotted notation) beyond what already works
+- Any other Scan/Query parameters

--- a/openspec/changes/fix-dynamodb-scan-filter-expression/specs/dynamodb-scan-filter-expression/spec.md
+++ b/openspec/changes/fix-dynamodb-scan-filter-expression/specs/dynamodb-scan-filter-expression/spec.md
@@ -1,0 +1,54 @@
+# Spec: DynamoDB Scan FilterExpression
+
+## MODIFIED Requirements
+
+### Requirement: scan-filter-expression-match
+The DynamoDB provider SHALL return only items that satisfy the `FilterExpression`
+when one is supplied to a `Scan` request. Items whose attribute values do not
+match the expression SHALL be excluded from the response, and `Count` SHALL
+reflect the number of matching items.
+
+#### Scenario: scan with equality filter returns matching items
+Given a table containing items with attribute `status` values `"active"` and `"inactive"`
+When a Scan is performed with `FilterExpression=Attr('status').eq('active')`
+Then only items where `status = "active"` are returned
+And `Count` equals the number of matching items
+
+#### Scenario: scan with no matching items returns empty result
+Given a table containing items where no item has `status = "deleted"`
+When a Scan is performed with `FilterExpression=Attr('status').eq('deleted')`
+Then the response contains `Count=0` and an empty `Items` list
+
+#### Scenario: scan without filter returns all items
+Given a table containing multiple items
+When a Scan is performed without a `FilterExpression`
+Then all items are returned unchanged
+
+### Requirement: query-filter-expression-match
+The DynamoDB provider SHALL apply `FilterExpression` post-key-condition filtering
+during `Query`, returning only items that match both the key condition and the
+filter expression.
+
+#### Scenario: query with filter expression returns subset of key-matched items
+Given a table with items sharing a partition key but different non-key attribute values
+When a Query is performed with a `KeyConditionExpression` and a `FilterExpression`
+Then only items satisfying both conditions are returned
+
+### Requirement: filter-expression-dynamo-json-items
+The FilterExpression evaluator SHALL correctly compare attribute values from
+items stored in DynamoDB JSON format (e.g. `{"S": "value"}`) against expression
+attribute values. Attribute paths resolved from stored items SHALL be unwrapped
+to plain Python values before comparison, matching the behaviour of value
+references resolved from `ExpressionAttributeValues`.
+
+#### Scenario: equality comparison against DynamoDB-JSON-typed attribute succeeds
+Given an item stored as `{"x": {"S": "hello"}}` (DynamoDB JSON)
+And an expression `"x = :v"` with `ExpressionAttributeValues={":v": {"S": "hello"}}`
+When the filter expression is applied
+Then the item matches (evaluates to True)
+
+#### Scenario: numeric comparison against DynamoDB-JSON-typed attribute succeeds
+Given an item stored as `{"score": {"N": "42"}}`
+And an expression `"score > :min"` with `ExpressionAttributeValues={":min": {"N": "10"}}`
+When the filter expression is applied
+Then the item matches (evaluates to True)

--- a/openspec/changes/fix-dynamodb-scan-filter-expression/tasks.md
+++ b/openspec/changes/fix-dynamodb-scan-filter-expression/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Fix DynamoDB Scan FilterExpression Always Returns Empty
+
+## Ordered task list
+
+1. **Fix `_eval_path` in `expressions.py`**
+   Apply `_unwrap_dynamo_value` to the value returned when resolving an item
+   attribute path. This makes attribute resolution symmetric with value-ref
+   resolution.
+   - File: `lang/python/core/src/lws/providers/dynamodb/expressions.py`
+   - Method: `ExpressionEvaluator._eval_path`
+
+2. **Fix `_eval_name_ref` in `expressions.py`**
+   Apply `_unwrap_dynamo_value` to the value returned when resolving an
+   `#alias` attribute reference.
+   - File: `lang/python/core/src/lws/providers/dynamodb/expressions.py`
+   - Method: `ExpressionEvaluator._eval_name_ref`
+
+3. **Add DynamoDB-JSON-format unit tests to expression test files**
+   Add test cases that use DynamoDB-typed items (e.g. `{"x": {"S": "y"}}`)
+   to the existing expression evaluator unit tests, confirming equality,
+   numeric comparison, `begins_with`, and `contains` all work when attribute
+   values are DynamoDB-typed.
+   - Files: `test_dynamodb_expressions_comparison_operators.py`,
+     `test_dynamodb_expressions_expression_resolution.py`,
+     `test_dynamodb_expressions_functions.py`
+
+4. **Add FilterExpression unit tests to provider scan tests**
+   Add a `test_scan_with_filter_expression_returns_matching_items` test to
+   the existing `test_dynamodb_provider_scan.py`. Use DynamoDB-JSON-format
+   items as they would be stored in SQLite.
+   - File: `tests/unit/providers/test_dynamodb_provider_scan.py`
+
+5. **Add FilterExpression unit tests to provider query tests**
+   Add a `test_query_with_filter_expression_returns_matching_items` test to
+   the existing `test_dynamodb_provider_query.py`.
+   - File: `tests/unit/providers/test_dynamodb_provider_query.py`
+
+6. **Add filtered-scan Gherkin scenario to `scan.feature`**
+   Add a `@minimal @happy @scan` scenario: items are put into the table,
+   a Scan with a `FilterExpression` is performed, and only matching items
+   are returned.
+   - File: `lang/specification/core/informal/dynamodb/scan.feature`
+
+7. **Validate all existing tests pass**
+   Run `make -C lang/python/core check` and confirm no regressions.


### PR DESCRIPTION
## Summary

- `_eval_path` and `_eval_name_ref` in `expressions.py` returned raw DynamoDB-typed dicts (`{"S": "value"}`) instead of unwrapping them, causing every FilterExpression comparison against items stored in DynamoDB JSON format to fail silently (returning zero results)
- Fixed by applying `_unwrap_dynamo_value` at the point of attribute resolution, consistent with the existing behaviour of `_eval_value_ref`

## Test plan

- [ ] Unit tests added for DynamoDB-JSON-format items in comparison, function, and resolution expression evaluator tests
- [ ] Provider-level scan and query tests with DynamoDB-JSON items and FilterExpression
- [ ] Integration BDD scenario added to `scan.feature` and wired in both core integration tests and SDK e2e tests
- [ ] All pre-commit hooks pass locally (lint, unit, e2e-minimal, architecture)

🤖 Generated with [Claude Code](https://claude.ai/code)