### PR TITLE
Align local-web-services and SDK versions to 0.19.0

### DIFF
--- a/lang/python/core/pyproject.toml
+++ b/lang/python/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-web-services"
-version = "0.18.0"
+version = "0.19.0"
 description = "Run AWS CDK applications locally - accelerate development with agentic code editors"
 readme = "README.md"
 license = "MIT"

--- a/lang/python/sdk/pyproject.toml
+++ b/lang/python/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "local-web-services-python-sdk"
-version = "0.2.2"
+version = "0.19.0"
 description = "Python testing SDK for local-web-services — in-process pytest fixtures and boto3 helpers"
 readme = "README.md"
 license = "MIT"
@@ -21,7 +21,7 @@ dependencies = [
     "httpx>=0.27.0",
     "botocore>=1.34.0",
     "pyyaml>=6.0",
-    "local-web-services>=0.18.0",
+    "local-web-services>=0.19.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bumps `local-web-services` from 0.18.0 → 0.19.0
- Bumps `local-web-services-python-sdk` from 0.2.2 → 0.19.0
- Updates SDK lower-bound dependency to `local-web-services>=0.19.0`

Both packages now share the same version number, making compatible pairs unambiguous.

## Root Cause (fixes #67)

`local-web-services-python-sdk==0.2.0` declared `local-web-services>=0.18.0` as a dependency and referenced the `fake` symbol names (`aws_operation_fake`, `fakeserver`, `aws_fake=`) introduced by the `mock→fake` rename. However the published server only reached 0.9.0 on PyPI, and the in-repo 0.18.0 still carried the old `mock` names — the version was never bumped after the rename landed. This caused:

```
RuntimeError: LwsSession failed to start:
  No module named 'lws.providers._shared.aws_operation_fake'
```

## Test plan

- [x] All pre-commit checks pass (lint, unit tests, architecture tests, e2e-minimal)
- [ ] Verify `pip install local-web-services-python-sdk==0.19.0` resolves `local-web-services==0.19.0` correctly after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)